### PR TITLE
Add config for deploying via kubernetes

### DIFF
--- a/green_box.yml
+++ b/green_box.yml
@@ -6,10 +6,22 @@ info:
 host: localhost:8080
 schemes:
   - https
-basePath: /v1
 produces:
   - application/json
 paths:
+  /:
+    get:
+      summary: health check
+      operationId: 'green_box.api.health.get'
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/HealthCheckResponse'
+        default:
+          description: Error
+          schema:
+            type: string
   /notifications:
     post:
       summary: Send notifications
@@ -64,3 +76,8 @@ definitions:
             type: string
           id:
             type: string
+  HealthCheckResponse:
+    type: object
+    properties:
+      status:
+        type: string

--- a/green_box/api/health.py
+++ b/green_box/api/health.py
@@ -1,0 +1,6 @@
+import logging
+
+def get():
+    logger = logging.getLogger('green-box')
+    logger.info("Health check request received")
+    return dict(status="healthy")

--- a/kubernetes/kubernetes.sh
+++ b/kubernetes/kubernetes.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Create listener cluster
+gcloud container clusters create listener
+
+# Create deployment
+kubectl create -f listener-deployment.yaml --record
+
+# Create service
+kubectl create -f listener-service.yaml --record
+
+# Create ingress
+kubectl create -f listener-ingress.yaml --record

--- a/kubernetes/listener-deployment.yaml
+++ b/kubernetes/listener-deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: listener
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: listener
+    spec:
+      containers:
+      - name: listener
+        image: gcr.io/broad-dsde-mint-dev/listener:v2
+        ports:
+        - containerPort: 8080

--- a/kubernetes/listener-ingress.yaml
+++ b/kubernetes/listener-ingress.yaml
@@ -1,0 +1,8 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: listener
+spec:
+  backend:
+    serviceName: listener
+    servicePort: 8080

--- a/kubernetes/listener-service.yaml
+++ b/kubernetes/listener-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: listener
+spec:
+  type: NodePort
+  selector:
+    app: listener
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 touch test_key.json
-docker build -t gcr.io/broad-dsde-mint-dev/green-node:test .
+docker build -t gcr.io/broad-dsde-mint-dev/listener:test .
 
-docker run gcr.io/broad-dsde-mint-dev/green-node:test bash -c "cd test && python -m unittest -v test_service"
+docker run gcr.io/broad-dsde-mint-dev/listener:test bash -c "cd test && python -m unittest -v test_service"

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -6,7 +6,7 @@ import sys
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, pkg_root)
 
-from green_box.api import notifications
+import green_box.api as api
 
 class TestService(unittest.TestCase):
 
@@ -17,24 +17,27 @@ class TestService(unittest.TestCase):
                 'bundle_version': 'bar'
             }
         }
-        uuid, version = notifications.extract_uuid_version(body)
+        uuid, version = api.notifications.extract_uuid_version(body)
         self.assertEqual(uuid, 'foo')
         self.assertEqual(version, 'bar')
 
     def test_compose_inputs(self):
-        inputs = notifications.compose_inputs('foo', 12, 'baz')
+        inputs = api.notifications.compose_inputs('foo', 12, 'baz')
         self.assertEqual(inputs['mock_smartseq2.bundle_uuid'], 'foo')
         self.assertEqual(inputs['mock_smartseq2.bundle_version'], '"12"')
         self.assertEqual(inputs['mock_smartseq2.provenance_script'], 'baz')
 
     def test_is_authenticated_no_auth_header(self):
-        self.assertEquals(notifications.is_authenticated({'foo': 'bar'}, 'baz'), False)
+        self.assertEquals(api.notifications.is_authenticated({'foo': 'bar'}, 'baz'), False)
 
     def test_is_authenticated_wrong_auth_value(self):
-        self.assertEquals(notifications.is_authenticated({'auth': 'bar'}, 'foo'), False)
+        self.assertEquals(api.notifications.is_authenticated({'auth': 'bar'}, 'foo'), False)
 
     def test_is_authenticated_valid(self):
-        self.assertEquals(notifications.is_authenticated({'auth': 'bar'}, 'bar'), True)
+        self.assertEquals(api.notifications.is_authenticated({'auth': 'bar'}, 'bar'), True)
+
+    def test_health_check(self):
+        self.assertEquals(api.health.get(), dict(status='healthy'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In order to deploy in Google Container Engine / Kubernetes we need a bunch of configuration files to define the deployment, the service, and the ingress. This PR adds those config files and a script that uses them to set up a container engine cluster and does the deployment.

See https://elastc.com/c/UwfbQgK_/87-prototype-kubernetes-for-mint