### PR TITLE
Rename tls secret

### DIFF
--- a/kubernetes/listener-ingress.yaml
+++ b/kubernetes/listener-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     kubernetes.io/ingress.global-static-ip-name: listener
 spec:
   tls:
-    - secretName: tls-secret
+    - secretName: hca-tls-secret
   backend:
     serviceName: listener
     servicePort: 8080


### PR DESCRIPTION
Just renamed the secret to better reflect what it is - a cert and key tied to humancellatlas.org.