### PR TITLE
Ac listener startup checks

### DIFF
--- a/green_box/__init__.py
+++ b/green_box/__init__.py
@@ -4,23 +4,20 @@
 Green box description FIXME: elaborate
 """
 
-import os, sys, json, time, logging
-from datetime import datetime, timedelta
-
-from flask import Flask, request, redirect, jsonify
+import os
+import json
+import logging
 import connexion
 from connexion.resolver import RestyResolver
-
+from .config import ListenerConfig
 logging.basicConfig(level=logging.DEBUG)
 
+
 app = connexion.App(__name__)
-app.app.config['MAX_CONTENT_LENGTH'] = 10 * 1000
 
 config_path = os.environ['listener_config']
 with open(config_path) as f:
-    config = json.load(f)
-    for key in config:
-        app.app.config[key] = config[key]
+    app.app.config = ListenerConfig(json.load(f), app.app.config)
 
 resolver = RestyResolver("green_box.api", collection_endpoint_name="list")
 app.add_api('../green_box.yml', resolver=resolver, validate_responses=True)

--- a/green_box/api/notifications.py
+++ b/green_box/api/notifications.py
@@ -5,15 +5,18 @@ import logging
 import json
 import subprocess
 import time
-from collections import namedtuple, OrderedDict
 from flask import make_response, current_app
+
+
+def get_filename_from_gs_link(link):
+    """get the filename corresponding to a google_storage link"""
+    return link.split('/')[-1]
+
 
 def post(body):
     # Check authentication
     logger = logging.getLogger('green-box')
-    ordered_config = OrderedDict(current_app.config)
-    Config = namedtuple('config', ordered_config.keys())
-    green_config = Config(*ordered_config.values())
+    green_config = current_app.config
     if not is_authenticated(connexion.request.args, green_config.notification_token):
         time.sleep(1)
         return response_with_server_header(dict(error='Unauthorized'), 401)
@@ -25,35 +28,37 @@ def post(body):
     uuid, version, subscription_id = extract_uuid_version_subscription_id(body)
 
     # Find wdl config where the subscription_id matches the notification's subscription_id
-    id_matches = [wdl for wdl in green_config.wdls if wdl.get('subscription_id') == subscription_id]
+    id_matches = [wdl for wdl in green_config.wdls if wdl.subscription_id == subscription_id]
     if len(id_matches) == 0:
-        return response_with_server_header(dict(error='Not Found: No wdl config found with subscription id {}'.format(subscription_id)), 404)
-    elif len(id_matches) > 1:
-        return response_with_server_header(dict(error='Internal Server Error: More than one wdl config found with subscription id {}'.format(subscription_id)), 500)
+        return response_with_server_header(
+            dict(error='Not Found: No wdl config found with subscription id {}'
+                       ''.format(subscription_id)), 404)
+    wdl = id_matches[0]
 
     # Prepare inputs
-    wdl = id_matches[0]
-    workflow_name = wdl.get('workflow_name')
-    inputs = compose_inputs(workflow_name, uuid, version, green_config.provenance_script)
+    inputs = compose_inputs(wdl.workflow_name, uuid, version)
     with open('cromwell_inputs.json', 'w') as f:
         json.dump(inputs, f)
 
     # Start workflow
     logger.info(wdl)
-    logger.info('Launching {0} workflow in Cromwell'.format(workflow_name))
+    logger.info('Launching {0} workflow in Cromwell'.format(wdl.workflow_name))
 
-    # Get files from gcs
-    subprocess.check_output(['gsutil', 'cp', wdl['wdl_cloud_path'], '.'])
-    subprocess.check_output(['gsutil', 'cp', wdl['default_inputs_cloud_path'], '.'])
-    subprocess.check_output(['gsutil', 'cp', wdl['wdl_deps_cloud_path'], '.'])
-    subprocess.check_output(['gsutil', 'cp', wdl['options_cloud_path'], '.'])
+    # Get files from gcs # todo change to using google.cloud.storage
+    subprocess.check_output(['gsutil', 'cp', wdl.wdl_link, '.'])
+    subprocess.check_output(['gsutil', 'cp', wdl.wdl_default_inputs_link, '.'])
+    subprocess.check_output(['gsutil', 'cp', wdl.wdl_deps_link, '.'])
+    subprocess.check_output(['gsutil', 'cp', wdl.options_link, '.'])
 
-    wdl_file = wdl['wdl_file']
-    wdl_deps_file = wdl['wdl_deps_file']
-    wdl_default_inputs_file = wdl['default_inputs_file']
-    options_file = wdl['options_file']
-    cromwell_response = start_workflow(wdl_file, wdl_deps_file, 'cromwell_inputs.json',
-                                        wdl_default_inputs_file, options_file, green_config)
+    # get filenames from links
+    wdl_file = get_filename_from_gs_link(wdl.wdl_link)
+    wdl_default_inputs_file = get_filename_from_gs_link(wdl.wdl_default_inputs_link)
+    wdl_deps_file = get_filename_from_gs_link(wdl.wdl_deps_link)
+    options_file = get_filename_from_gs_link(wdl.options_link)
+
+    cromwell_response = start_workflow(
+        wdl_file, wdl_deps_file, 'cromwell_inputs.json',
+        wdl_default_inputs_file, options_file, green_config)
 
     # Respond
     if cromwell_response.status_code > 201:
@@ -62,18 +67,21 @@ def post(body):
     logger.info(cromwell_response.json())
     return response_with_server_header(cromwell_response.json())
 
+
 def response_with_server_header(body, status=200):
     response = make_response(json.dumps(body), status)
     response.headers['Server'] = 'Secondary Analysis Service'
     response.headers['Content-type'] = 'application/json'
     return response
 
+
 def is_authenticated(args, token):
-    if not 'auth' in args:
+    if 'auth' not in args:
         return False
     elif args['auth'] != token:
         return False
     return True
+
 
 def extract_uuid_version_subscription_id(msg):
     uuid = msg["match"]["bundle_uuid"]
@@ -81,17 +89,16 @@ def extract_uuid_version_subscription_id(msg):
     subscription_id = msg["subscription_id"]
     return uuid, version, subscription_id
 
-def compose_inputs(workflow_name, uuid, version, provenance_script):
-    inputs = {}
-    inputs[workflow_name + '.bundle_uuid'] = uuid
-    inputs[workflow_name + '.bundle_version'] = '{0}'.format(version)
-    inputs[workflow_name + '.provenance_script'] = provenance_script
-    return inputs
+
+def compose_inputs(workflow_name, uuid, version):
+    return {workflow_name + '.bundle_uuid': uuid,
+            workflow_name + '.bundle_version': '{0}'.format(version)}
+
 
 def start_workflow(wdl_file, zip_file, inputs_file, inputs_file2, options_file, green_config):
     with open(wdl_file, 'rb') as wdl, open(zip_file, 'rb') as deps, \
-        open(inputs_file, 'rb') as inputs, open(inputs_file2, 'rb') as inputs2, \
-        open(options_file, 'rb') as options:
+            open(inputs_file, 'rb') as inputs, open(inputs_file2, 'rb') as inputs2, \
+            open(options_file, 'rb') as options:
         files = {
           'wdlSource': wdl,
           'workflowInputs': inputs,
@@ -100,5 +107,8 @@ def start_workflow(wdl_file, zip_file, inputs_file, inputs_file2, options_file, 
           'workflowOptions': options
         }
 
-        response = requests.post(green_config.cromwell_url, files=files, auth=HTTPBasicAuth(green_config.cromwell_user, green_config.cromwell_password))
+        response = requests.post(
+            green_config.cromwell_url, files=files,
+            auth=HTTPBasicAuth(green_config.cromwell_user,
+                               green_config.cromwell_password))
         return response

--- a/green_box/config.py
+++ b/green_box/config.py
@@ -1,0 +1,127 @@
+import logging
+
+
+class Config:
+
+    def __init__(self, config_dictionary, flask_config_values=None):
+        """abstract class that defines some useful configuration checks for the listener
+
+        This object takes a dictionary of values and verifies them against expected_keys.
+         It additionally accepts values from a flask config object, which it merges
+         with the config_dictionary without doing additional checks.
+
+        :param dict config_dictionary: configuration values to be verified
+        :param flask_config_values: flask.config.Config configuration values, for example
+          those generated from a connexxion App
+        """
+        self.config_dictionary = config_dictionary
+        self._verify_fields()
+
+        # make keys accessible in the namespace, grab any extra flask arguments
+        for k, v in config_dictionary.items():
+            setattr(self, k, v)
+        if isinstance(flask_config_values, dict):
+            for k, v in flask_config_values.items():
+                setattr(self, k, v)
+
+    @property
+    def required_fields(self):
+        """abstract property, must be defined by subclasses"""
+        raise NotImplementedError
+
+    def _verify_fields(self):
+        """Verify wdl config contains valid entries for exactly the expected fields"""
+
+        wdl_keys = set(self.config_dictionary)
+        extra_keys = wdl_keys - self.required_fields
+        missing_keys = self.required_fields - wdl_keys
+        if missing_keys:
+            raise ValueError(
+                'The following WDL configuration is missing key(s): {keys}\n{wdl}'
+                ''.format(wdl=self.config_dictionary, keys=', '.join(missing_keys)))
+        if extra_keys:
+            logging.warning(
+                'The following WDL configuration has unexpected key(s): {keys}\n{wdl}'
+                ''.format(wdl=self.config_dictionary, keys=', '.join(extra_keys)))
+
+    def __eq__(self, other):
+        return isinstance(other, WdlConfig) and hash(self) == hash(other)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def to_string(self):
+        """recursively collapse a config object into a hashable string"""
+        result = ''
+        for v in self.required_fields:
+            field_value = getattr(self, v)
+            if isinstance(field_value, (str, unicode, int)):
+                result += str(field_value)
+            elif isinstance(field_value, Config):
+                result += field_value.to_string()
+            else:
+                raise ValueError('Config fields must either be strings or config objects')
+        return result
+
+    def __hash__(self):
+        return hash(self.to_string())
+
+    # needed for flask interface
+    def __getitem__(self, item):
+        return getattr(self, item)
+
+
+class WdlConfig(Config):
+    """subclass of Config to check WDL configurations"""
+
+    @property
+    def required_fields(self):
+        return {
+            'subscription_id',
+            'wdl_link',
+            'workflow_name',
+            'wdl_deps_link',
+            'wdl_default_inputs_link',
+            'options_link'
+        }
+
+
+class ListenerConfig(Config):
+    """subclass of Config to check listener configurations"""
+
+    def __init__(self, json_config_object, *args, **kwargs):
+
+        # parse the wdls section
+        wdl_configs = []
+        try:
+            for wdl in json_config_object['wdls']:
+                wdl_configs.append(WdlConfig(wdl))
+        except KeyError:
+            raise ValueError('supplied config file must contain a "wdls" section.')
+        self._verify_wdl_configs(wdl_configs)
+        json_config_object['wdls'] = wdl_configs
+
+        Config.__init__(self, json_config_object, *args, **kwargs)
+
+    @property
+    def required_fields(self):
+        return {
+            'wdls',
+            'notification_token',
+            'cromwell_user',
+            'cromwell_url',
+            'cromwell_password',
+            'MAX_CONTENT_LENGTH'
+        }
+
+    @staticmethod
+    def _verify_wdl_configs(wdl_configs):
+        """Additional verification for wdl configurations"""
+        if len(wdl_configs) != len(set(wdl_configs)):
+            logging.warning('duplicate wdl definitions detected in config.json')
+
+        if len(wdl_configs) != len(set([wdl.subscription_id for wdl in wdl_configs])):
+            raise ValueError(
+                'One or more wdl specifications contains a duplicated subscription ID '
+                'but have non-identical configurations. Please check configuration file '
+                'contents.')

--- a/test/config.json
+++ b/test/config.json
@@ -3,12 +3,31 @@
   "cromwell_user": "test",
   "cromwell_password": "test",
   "cromwell_url": "test",
-  "provenance_script": "test",
-  "wdl_cloud_path": "test",
-  "wdl_file": "test",
-  "workflow_name": "test",
-  "wdl_deps_cloud_path": "test",
-  "wdl_deps_file": "test",
-  "default_inputs_cloud_path": "test",
-  "default_inputs_file": "test"
+  "MAX_CONTENT_LENGTH": 10000,
+  "wdls": [
+    {
+      "subscription_id": 222,
+      "wdl_link": "gs://broad-dsde-mint-dev-teststorage/prepare_and_analyze_ss2_single_sample.wdl",
+      "workflow_name": "PrepareAndAnalyzeSs2RsemSingleSample",
+      "wdl_deps_link": "gs://broad-dsde-mint-dev-teststorage/ss2_single_sample_analysis_only.zip",
+      "wdl_default_inputs_link": "gs://broad-dsde-mint-dev-teststorage/prepare_and_analyze_ss2_single_sample_default_inputs.json",
+      "options_link": "gs://broad-dsde-mint-dev/an_options_file.json"
+    },
+    {
+      "subscription_id": 333,
+      "workflow_name": "PrepareAndAnalyzeMockSmartseq2",
+      "wdl_link": "gs://broad-dsde-mint-dev-teststorage/prepare_and_analyze_mock_smartseq2.wdl",
+      "wdl_default_inputs_link": "gs://broad-dsde-mint-dev-teststorage/prepare_and_analyze_mock_smartseq2_default_inputs.json",
+      "wdl_deps_link": "gs://broad-dsde-mint-dev-teststorage/mock_smartseq2.zip",
+      "options_link": "gs://broad-dsde-mint-dev/an_options_file.json"
+    },
+    {
+      "subscription_id": 1,
+      "wdl_link": "gs://broad-dsde-mint-dev-teststorage/wrapper_ss2_single_sample.wdl",
+      "workflow_name": "WrapperSs2RsemSingleSample",
+      "wdl_deps_link": "gs://broad-dsde-mint-dev-teststorage/ss2_single_sample_analysis_only.zip",
+      "wdl_default_inputs_link": "gs://broad-dsde-mint-dev-teststorage/wrapper_ss2_single_sample_example_static.json",
+      "options_link": "gs://broad-dsde-mint-dev/an_options_file.json"
+    }
+  ]
 }

--- a/test/test.sh
+++ b/test/test.sh
@@ -3,4 +3,4 @@
 touch test_key.json
 docker build -t gcr.io/broad-dsde-mint-dev/listener:test .
 
-docker run -e listener_config=config.json gcr.io/broad-dsde-mint-dev/listener:test bash -c "cd test && python -m unittest -v test_service"
+docker run -e listener_config=config.json gcr.io/broad-dsde-mint-dev/listener:test bash -c "cd test && python -m unittest -v test_service test_validate_config"

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -8,6 +8,7 @@ sys.path.insert(0, pkg_root)
 
 import green_box.api as api
 
+
 class TestService(unittest.TestCase):
 
     def test_extract_uuid_version(self):
@@ -24,10 +25,9 @@ class TestService(unittest.TestCase):
         self.assertEqual(subscription_id, 222)
 
     def test_compose_inputs(self):
-        inputs = api.notifications.compose_inputs('foo', 'bar', 'baz', 'asdf')
+        inputs = api.notifications.compose_inputs('foo', 'bar', 'baz')
         self.assertEqual(inputs['foo.bundle_uuid'], 'bar')
         self.assertEqual(inputs['foo.bundle_version'], 'baz')
-        self.assertEqual(inputs['foo.provenance_script'], 'asdf')
 
     def test_is_authenticated_no_auth_header(self):
         self.assertEquals(api.notifications.is_authenticated({'foo': 'bar'}, 'baz'), False)

--- a/test/test_validate_config.py
+++ b/test/test_validate_config.py
@@ -1,0 +1,78 @@
+import unittest
+import json
+from copy import deepcopy
+import green_box.config as validate_config
+
+
+class TestStartupVerification(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """load the config file"""
+        with open('config.json', 'rb') as f:
+            cls.correct_test_config = json.load(f)
+
+    def test_correct_config_throws_no_errors(self):
+        config = deepcopy(self.correct_test_config)
+
+        try:  # make sure ListenerConfig executes
+            result = validate_config.ListenerConfig(config)
+        except BaseException as exception:
+            self.fail(
+                'ListenerConfig constructor raised an exception: {exception}'
+                .format(exception=exception))
+
+        # check correct type
+        self.assertIsInstance(result, validate_config.ListenerConfig)
+
+    def test_config_missing_required_field_throws_value_error(self):
+
+        def delete_wdl_field(field_name):
+            """return a config object whose first wdl config is missing a field"""
+            config = deepcopy(self.correct_test_config)
+            del config['wdls'][0][field_name]
+            return config
+
+        mangled_config = delete_wdl_field('subscription_id')
+        self.assertRaises(ValueError, validate_config.ListenerConfig, mangled_config)
+        mangled_config = delete_wdl_field('workflow_name')
+        self.assertRaises(ValueError, validate_config.ListenerConfig, mangled_config)
+        mangled_config = delete_wdl_field('wdl_link')
+        self.assertRaises(ValueError, validate_config.ListenerConfig, mangled_config)
+        mangled_config = delete_wdl_field('wdl_default_inputs_link')
+        self.assertRaises(ValueError, validate_config.ListenerConfig, mangled_config)
+        mangled_config = delete_wdl_field('wdl_deps_link')
+        self.assertRaises(ValueError, validate_config.ListenerConfig, mangled_config)
+
+    def test_config_duplicate_wdl_raises_value_error(self):
+
+        def add_duplicate_wdl_definition():
+            """add the first wdl definition to the end of the 'wdls' json section"""
+            config = deepcopy(self.correct_test_config)
+            config['wdls'].append(config['wdls'][0])
+            return config
+
+        mangled_config = add_duplicate_wdl_definition()
+        self.assertRaises(ValueError, validate_config.ListenerConfig, mangled_config)
+
+    def test_listener_config_exposes_all_methods_requested_in_notifications(self):
+        # test that the call smade in notifications refer to attributes that
+        # ListenerConfig exposes
+        config = validate_config.ListenerConfig(self.correct_test_config)
+        requested_listener_attributes = [
+            'notification_token', 'wdls', 'cromwell_url', 'cromwell_user',
+            'cromwell_password', 'MAX_CONTENT_LENGTH']
+        for attr in requested_listener_attributes:
+            self.assertTrue(hasattr(config, attr), 'missing attribute %s' % attr)
+
+        # get an example wdl to test
+        wdl = config.wdls[0]
+        requested_wdl_attributes = [
+            'subscription_id', 'wdl_link', 'workflow_name', 'wdl_default_inputs_link',
+            'wdl_deps_link', 'options_link']
+        for attr in requested_wdl_attributes:
+            self.assertTrue(hasattr(wdl, attr), 'missing attribute %s' % attr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces a `Config` class that has methods to check the correctness of `config.json`

#### This `Config` class is subclassed twice to do specialized checks: 
- `WdlConfig` to check wdl specifications
- `ListenerConfig` to check the config.json top-level keys

#### Current tests for `config.json`:
- checks for any missing required keys
- checks for any unexpected keys
- checks for duplicated keys
- checks for duplicated wdl definitions
- checks for multiple wdl definitions with the same subscription id

#### Implementation Notes
1. As of now, the `unittests` are all contained in the same file; because of the way `green_box.__init__` is configured to run code, normal separation of testing files is tricky. 
2. By switching to a `Config` class, I was able to simplify a lot of the calls made in `notifications.py`. There is a small amount of additional code that was required use this class as a drop-in replacement for the dictionary-like object expected by the `connexion` app. 
3. Please note the "true" config file that is not stored in this repository will need to be reflect the simplification of the wdl specification in `config.json`. Currently there are both `<arg>_path` and `<arg>_file`, which has been simplified to `<arg>_link` with the file automatically inferred. 
4. In the process of testing this, I realized I was able to break `notifications.py` in many ways that are not caught by the `test.sh` script; we should probably make those tests more robust. 