### PR TITLE
Cw standardize docker versioning 202

### DIFF
--- a/kubernetes/listener-deployment.yaml
+++ b/kubernetes/listener-deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: listener
-        image: gcr.io/broad-dsde-mint-dev/listener:real-smartseq2-v10
+        image: gcr.io/broad-dsde-mint-dev/listener:0.1.0
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-touch test_key.json
 docker build -t gcr.io/broad-dsde-mint-dev/listener:test ..
 
 # Tell Jenkins to run both unittests in root folder and listener_utils package folder


### PR DESCRIPTION
For this PR, I made three slight changes:
1. Added standardized version tag to the docker images on gcr.io for both staging and dev project.
2. Removed the outdated `test_key.json` usage in Secondary-Analysis code base.
3. Modified Kubernetes deployment configuration to use standardized version tag. (Note: This won't take actual effect until we actually rebuild the docker image and update dev/staging code on Google Cloud).