### PR TITLE
Bug fixes for cromwell inputs json

### DIFF
--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -45,11 +45,10 @@ def post(body):
     url_to_contents = lira_utils.download_to_map([wdl.analysis_wdl, green_config.submit_wdl])
     wdl_deps_file = lira_utils.make_zip_in_memory(url_to_contents)
 
-    with open('cromwell_inputs.json') as cromwell_inputs_file:
-        cromwell_response = cromwell_tools.start_workflow(
-            wdl_file, wdl_deps_file, cromwell_inputs_file,
-            wdl_default_inputs_file, options_file, green_config.cromwell_url,
-            green_config.cromwell_user, green_config.cromwell_password)
+    cromwell_response = cromwell_tools.start_workflow(
+        wdl_file, wdl_deps_file, cromwell_inputs_file,
+        wdl_default_inputs_file, options_file, green_config.cromwell_url,
+        green_config.cromwell_user, green_config.cromwell_password)
 
     # Respond
     if cromwell_response.status_code > 201:

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -47,16 +47,20 @@ def extract_uuid_version_subscription_id(msg):
     return uuid, version, subscription_id
 
 
-def compose_inputs(workflow_name, uuid, version):
+def compose_inputs(workflow_name, uuid, version, env):
     """Create Cromwell inputs file containing bundle uuid and version.
 
     :param str workflow_name: The name of the workflow.
     :param str uuid: uuid of the bundle.
     :param str version: version of the bundle.
+    :param str env: runtime environment, such as 'dev', 'staging', 'int' or 'prod'.
     :return dict: A dictionary of workflow inputs.
     """
-    return {workflow_name + '.bundle_uuid': uuid,
-            workflow_name + '.bundle_version': str(version)}
+    return {
+        workflow_name + '.bundle_uuid': uuid,
+        workflow_name + '.bundle_version': version,
+        workflow_name + '.runtime_environment': env
+    }
 
 
 def download_to_map(urls):

--- a/lira/test/test_lira_utils.py
+++ b/lira/test/test_lira_utils.py
@@ -37,9 +37,10 @@ class TestUtils(unittest.TestCase):
 
     def test_compose_inputs(self):
         """Test if compose_inputs can correctly create Cromwell inputs file containing bundle uuid and version"""
-        inputs = lira_utils.compose_inputs('foo', 'bar', 'baz')
+        inputs = lira_utils.compose_inputs('foo', 'bar', 'baz', 'asdf')
         self.assertEqual(inputs['foo.bundle_uuid'], 'bar')
         self.assertEqual(inputs['foo.bundle_version'], 'baz')
+        self.assertEquals(inputs['foo.runtime_environment'], 'asdf')
 
     def test_download_to_map(self):
         """Test download_to_map with local files to ensure it builds the map of paths to contents correctly"""


### PR DESCRIPTION
Fix two bugs in lira related to the inputs json file. These were introduced due to bad merge conflict resolution on my part when rebasing and merging #36.