### PR TITLE
Update script and instructions for deploying TLS secret

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,8 +1,10 @@
 ## Create a new kubernetes listener deployment
 
 ### Requirements:
-- Install [gcloud](https://cloud.google.com/sdk/)
-- Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/): `gcloud components install kubectl`
+1. Install [gcloud](https://cloud.google.com/sdk/)
+2. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/): `gcloud components install kubectl`
+3. `gcloud auth login`
+4. `gcloud config set project [project]`
 
 ### Setup:
 1. Create gcloud project for the new deployment (Each deployment corresponds to a separate gcloud project. e.g. the staging deployment uses `broad-dsde-mint-staging`)
@@ -26,8 +28,8 @@
 
 ## Update existing deployment
 
-Switch to the correct environment:  
-1. Get cluster credentials: `gcloud container clusters --[project] [env] get-credentials listener`
+Switch to the correct environment:
+1. Get cluster credentials: `gcloud container clusters --project [project] --zone [zone] get-credentials listener`
 2. Find the context name for the environment you want: `kubectl config get-contexts`
 3. Set the context: `kubectl config set-context [name]` where `name` is the context name, e.g. gke_broad-dsde-mint-dev_us-central1-b_listener
 
@@ -37,6 +39,14 @@ Deploy new code:
 3. Update `listener-deployment.yaml` image with the pushed docker image
 4. Set listener config secret `bash populate-listener-config-secret.sh`
 5. Update deployment: `kubectl apply -f listener-deployment.yaml --record`
+
+Deploy and use new tls secret:
+To obtain a new certificate, see [HumanCellAtlas/secondary-analysis/certs/README.md](https://github.com/HumanCellAtlas/secondary-analysis/blob/master/certs/README.md).
+Once you've obtained the new certificate, follow the instructions below.
+1. `bash populate-tls-secret.sh hca-tls-secret-yyyy-mm-dd /path/to/local/certs`
+2. Edit listener-ingress.yaml to use new secret
+3. `kubectl apply -f listener-ingress.yaml`
+4. Test: `curl https://pipelines.[env].data.humancellatlas.org` and `kubectl describe ingress listener` for detailed status. Expect to get 502 errors for ~15 minutes while things update.
 
 Check the status of new deployment:
 1. Get all pods: `kubectl get pods`

--- a/kubernetes/populate-tls-secret.sh
+++ b/kubernetes/populate-tls-secret.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
-kubectl create secret tls hca-tls-secret \
-  --cert=/etc/secondary-analysis/fullchain.pem \
-  --key=/etc/secondary-analysis/privkey.pem
+secret_name=$1
+cert_dir=$2
+
+kubectl create secret tls $secret_name \
+  --cert=$cert_dir/fullchain.pem \
+  --key=$cert_dir/privkey.pem


### PR DESCRIPTION
Pass in certificate and key locations as parameters instead of hard coding them. For context, see https://elastc.com/c/SyXB5BII/405-get-new-ssl-certificates.