### PR TITLE
Fix requirements txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ google-auth
 google-cloud-storage
 flask
 requests
-git+git://github.com/broadinstitute/cromwell-tools.git@ds_move_make_zip_to_cromwell_tools_310
+git+git://github.com/broadinstitute/cromwell-tools.git
 git+git://github.com/HumanCellAtlas/pipeline-tools.git


### PR DESCRIPTION
We merged and deleted the branch in cromwell-tools that is currently specified in Lira's requirements.txt.

See https://elastc.com/c/mPQyBcby/412-coordinating-with-jackie-on-integration-test for context.