### PR TITLE
Support analysis wdls with their own imports

### DIFF
--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -42,7 +42,7 @@ def post(body):
     options_file = cromwell_tools.download(wdl.options_link)
 
     # Create zip of analysis and submit wdls
-    url_to_contents = cromwell_tools.download_to_map([wdl.analysis_wdl, green_config.submit_wdl])
+    url_to_contents = cromwell_tools.download_to_map(wdl.analysis_wdls + [green_config.submit_wdl])
     wdl_deps_file = cromwell_tools.make_zip_in_memory(url_to_contents)
 
     cromwell_response = cromwell_tools.start_workflow(

--- a/lira/config.py
+++ b/lira/config.py
@@ -3,7 +3,7 @@
 import logging
 
 
-class Config:
+class Config(object):
 
     def __init__(self, config_dictionary, flask_config_values=None):
         """abstract class that defines some useful configuration checks for the listener
@@ -17,7 +17,6 @@ class Config:
           those generated from a connexxion App
         """
         self.config_dictionary = config_dictionary
-        self._verify_fields()
 
         # make keys accessible in the namespace, grab any extra flask arguments
         for k, v in config_dictionary.items():
@@ -25,6 +24,8 @@ class Config:
         if isinstance(flask_config_values, dict):
             for k, v in flask_config_values.items():
                 setattr(self, k, v)
+
+        self._verify_fields()
 
     @property
     def required_fields(self):
@@ -57,7 +58,7 @@ class Config:
         result = ''
         for v in self.required_fields:
             field_value = getattr(self, v)
-            if isinstance(field_value, (str, unicode, int)):
+            if isinstance(field_value, (str, unicode, int, list)):
                 result += str(field_value)
             elif isinstance(field_value, Config):
                 result += field_value.to_string()
@@ -84,15 +85,20 @@ class WdlConfig(Config):
         return {
             'subscription_id',
             'wdl_link',
-            'analysis_wdl',
+            'analysis_wdls',
             'workflow_name',
             'wdl_default_inputs_link',
             'options_link'
         }
 
+    def _verify_fields(self):
+        super(WdlConfig, self)._verify_fields()
+        if not isinstance(self.analysis_wdls, list):
+            raise TypeError('analysis_wdls must be a list')
+
     def __str__(self):
-        s = 'WdlConfig({0}, {1}, {2}, {3}, {4}, {5}, {6})'
-        return s.format(self.subscription_id, self.wdl_link, self.analysis_wdl,
+        s = 'WdlConfig({0}, {1}, {2}, {3}, {4}, {5})'
+        return s.format(self.subscription_id, self.wdl_link, self.analysis_wdls,
             self.workflow_name, self.wdl_default_inputs_link, self.options_link)
 
 class ListenerConfig(Config):

--- a/lira/test/data/config.json
+++ b/lira/test/data/config.json
@@ -1,26 +1,33 @@
 {
   "env": "dev",
-  "cromwell_url": "https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1", 
-  "cromwell_password": "test", 
-  "cromwell_user": "test", 
-  "notification_token": "test", 
-  "MAX_CONTENT_LENGTH": 10000, 
-  "submit_wdl": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/master/adapter_pipelines/submit.wdl", 
+  "cromwell_url": "https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1",
+  "cromwell_password": "test",
+  "cromwell_user": "test",
+  "notification_token": "test",
+  "MAX_CONTENT_LENGTH": 10000,
+  "submit_wdl": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/v0.1.5/adapter_pipelines/submit.wdl",
   "wdls": [
     {
-      "subscription_id": "3e3e176b-629f-46ea-b01d-e36bd650dc54", 
-      "analysis_wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/10x/count/count.wdl", 
-      "options_link": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/master/adapter_pipelines/10x/options.json", 
-      "wdl_default_inputs_link": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/master/adapter_pipelines/10x/adapter_example_static.json", 
-      "wdl_link": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/master/adapter_pipelines/10x/adapter.wdl", 
+      "subscription_id": "3e3e176b-629f-46ea-b01d-e36bd650dc54",
+      "analysis_wdls": ["https://raw.githubusercontent.com/HumanCellAtlas/skylab/10x_v0.1.0/10x/count/count.wdl"],
+      "options_link": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/10x_v0.1.0/adapter_pipelines/10x/options.json",
+      "wdl_default_inputs_link": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/10x_v0.1.0/adapter_pipelines/10x/adapter_example_static.json",
+      "wdl_link": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/v0.1.0/adapter_pipelines/10x/adapter.wdl",
       "workflow_name": "Adapter10xCount"
-    }, 
+    },
     {
-      "subscription_id": "dd17bb03-7634-47a4-9fd3-a55580ac3b1c", 
-      "analysis_wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/smartseq2_single_sample/ss2_single_sample.wdl", 
-      "options_link": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/master/adapter_pipelines/smart_seq2/options.json", 
-      "wdl_default_inputs_link": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/master/adapter_pipelines/smart_seq2/adapter_example_static_demo.json", 
-      "wdl_link": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/master/adapter_pipelines/smart_seq2/adapter.wdl", 
+      "subscription_id": "dd17bb03-7634-47a4-9fd3-a55580ac3b1c",
+      "analysis_wdls": [
+        "https://raw.githubusercontent.com/HumanCellAtlas/skylab/smartseq2_v0.2.0/smartseq2_single_sample/ss2_single_sample.wdl",
+        "https://raw.githubusercontent.com/HumanCellAtlas/skylab/smartseq2_v0.2.0/smartseq2_single_sample/pipelines/hisat2_QC_pipeline.wdl",
+        "https://raw.githubusercontent.com/HumanCellAtlas/skylab/smartseq2_v0.2.0/smartseq2_single_sample/pipelines/hisat2_rsem_pipeline.wdl",
+        "https://raw.githubusercontent.com/HumanCellAtlas/skylab/smartseq2_v0.2.0/pipelines/tasks/hisat2.wdl",
+        "https://raw.githubusercontent.com/HumanCellAtlas/skylab/smartseq2_v0.2.0/pipelines/tasks/picard.wdl",
+        "https://raw.githubusercontent.com/HumanCellAtlas/skylab/smartseq2_v0.2.0/pipelines/tasks/rsem.wdl"
+      ],
+      "options_link": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/v0.1.5/adapter_pipelines/smart_seq2/options.json",
+      "wdl_default_inputs_link": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/v0.1.5/adapter_pipelines/smart_seq2/adapter_example_static_demo.json",
+      "wdl_link": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/v0.1.5/adapter_pipelines/smart_seq2/adapter.wdl",
       "workflow_name": "AdapterSs2RsemSingleSample"
     }
   ]

--- a/lira/test/test_config.py
+++ b/lira/test/test_config.py
@@ -47,8 +47,14 @@ class TestStartupVerification(unittest.TestCase):
         self.assertRaises(ValueError, config.ListenerConfig, mangled_config)
         mangled_config = delete_wdl_field('wdl_default_inputs_link')
         self.assertRaises(ValueError, config.ListenerConfig, mangled_config)
-        mangled_config = delete_wdl_field('analysis_wdl')
+        mangled_config = delete_wdl_field('analysis_wdls')
         self.assertRaises(ValueError, config.ListenerConfig, mangled_config)
+
+    def test_error_thrown_when_analysis_wdl_is_not_list(self):
+        test_config = deepcopy(self.correct_test_config)
+        test_config['wdls'][0]['analysis_wdls'] = 'bare string'
+        with self.assertRaises(TypeError):
+            config.ListenerConfig(test_config)
 
     def test_config_duplicate_wdl_raises_value_error(self):
 


### PR DESCRIPTION
Previously Lira was used only to launch monolithic analysis wdls. Now, we need to support launching analysis wdls that have their own imports.

To support this, the analysis_wdl field in the wdl config is now required to be a list (and is renamed to analysis_wdls). Also fixed an issue in `WdlConfig.__str__`, where the call to `.format` was expecting too many parameters.

See https://elastc.com/c/0v6eJH1B/465-updating-lira-to-handle-subworkflows
  