### PR TITLE
Fix bad docker cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get upgrade -y
-
-RUN apt-get -y install --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && \
+  apt-get -y install --no-install-recommends \
   python-pip \
   python-setuptools \
   vim \


### PR DESCRIPTION
Currently we have a RUN command in the Dockerfile that just does apt-get update, followed by a separate RUN command that does the actual apt-get installs.

Having these separated can cause issues because the install commands depend on information from that update command. Sometimes the update command gets added to the docker cache but the install command doesn't, which means that the install command tries to run based on out of date information.

Joining these in a single RUN command means that they'll always be in sync. Either they both get executed anew or the cache is used for both, so we shouldn't run into failed builds due to inconsistency anymore.

See comment in https://elastc.com/c/zCXY1Hjc/538-cache-wdls-and-static-inputs-in-lira