### PR TITLE
Register service account for CaaS

### DIFF
--- a/kubernetes/caas_login.sh
+++ b/kubernetes/caas_login.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# This script creates a service account in the specified gcloud project and registers it in FireCloud and SAM for use with Cromwell-as-a-service (CaaS).
+# Note: CaaS is only available in dev, so this script uses the develop versions of FireCloud and SAM
+
+GCLOUD_PROJECT=$1  # The gcloud project in which to create the service account
+ENV=$2  # The deployment environment associated with the gcloud project
+KEY_DIR=$3  # Where to save the service account key
+WORKFLOW_COLLECTION_ID=$4  # The name of the workflow-collection to create in SAM (e.g. "dev-workflows")
+FIRECLOUD_CONTACT_EMAIL=$5  # A contact email to use for the FireCloud service account
+FIRECLOUD_GROUP_NAME=$6  # The name of the user group to create in FireCloud to control workflow collection permissions (e.g. "write-access")
+VAULT_TOKEN_FILE=${VAULT_TOKEN_FILE:-"$HOME/.vault-token"}
+FIRECLOUD_URL="https://firecloud.dsde-dev.broadinstitute.org"
+
+
+#Set gcloud project
+gcloud config set project ${GCLOUD_PROJECT}
+
+echo "Creating CaaS service account and key"
+KEY_FILE_PATH=${KEY_DIR}/caas-${ENV}-key.json
+IAM_ACCOUNT_EMAIL=caas-account@${GCLOUD_PROJECT}.iam.gserviceaccount.com
+gcloud iam service-accounts create caas-account --display-name=caas-account
+gcloud iam service-accounts keys create ${KEY_FILE_PATH} --iam-account=${IAM_ACCOUNT_EMAIL}
+
+# Add key to vault
+docker run -it --rm -v ${VAULT_TOKEN_FILE}:/root/.vault-token -v ${KEY_DIR}:/keys broadinstitute/dsde-toolbox vault write secret/dsde/mint/${ENV}/listener/caas-${ENV}-key.json @/keys/caas-${ENV}-key.json
+
+# Clone firecloud-tools repo
+git clone git@github.com:broadinstitute/firecloud-tools.git
+cd firecloud-tools
+
+echo "Register the service account for use in Firecloud"
+./run.sh scripts/register_service_account/register_service_account.py -j ${KEY_FILE_PATH} -e ${FIRECLOUD_CONTACT_EMAIL} -u ${FIRECLOUD_URL}
+
+cd ..
+
+echo "Register the service account in SAM"
+./sam_registration.py ${KEY_FILE_PATH} ${WORKFLOW_COLLECTION_ID} ${FIRECLOUD_GROUP_NAME}

--- a/kubernetes/caas_login.sh
+++ b/kubernetes/caas_login.sh
@@ -9,7 +9,9 @@ WORKFLOW_COLLECTION_ID=$4  # The name of the workflow-collection to create in SA
 FIRECLOUD_CONTACT_EMAIL=$5  # A contact email to use for the FireCloud service account
 FIRECLOUD_GROUP_NAME=$6  # The name of the user group to create in FireCloud to control workflow collection permissions (e.g. "write-access")
 VAULT_TOKEN_FILE=${VAULT_TOKEN_FILE:-"$HOME/.vault-token"}
-FIRECLOUD_URL="https://firecloud.dsde-dev.broadinstitute.org"
+FIRECLOUD_URL=${FIRECLOUD_URL:-"https://firecloud.dsde-dev.broadinstitute.org"}
+FIRECLOUD_API_URL=${FIRECLOUD_URL:-"https://firecloud-orchestration.dsde-dev.broadinstitute.org"}
+SAM_URL=${SAM_URL:-"https://sam.dsde-dev.broadinstitute.org"}
 
 
 #Set gcloud project
@@ -34,4 +36,9 @@ echo "Register the service account for use in Firecloud"
 cd ..
 
 echo "Register the service account in SAM"
-./sam_registration.py ${KEY_FILE_PATH} ${WORKFLOW_COLLECTION_ID} ${FIRECLOUD_GROUP_NAME}
+./sam_registration.py \
+    --json_credentials ${KEY_FILE_PATH} \
+    --workflow_collection_id ${WORKFLOW_COLLECTION_ID} \
+    --firecloud_group_name ${FIRECLOUD_GROUP_NAME} \
+    --sam_url ${SAM_URL} \
+    --firecloud_api_url ${FIRECLOUD_API_URL}

--- a/kubernetes/sam_registration.py
+++ b/kubernetes/sam_registration.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+import argparse
+import requests
+import logging
+from firecloud import api as firecloud_api
+from oauth2client.service_account import ServiceAccountCredentials
+
+
+def register_service_account(json_credentials, workflow_collection_id):
+    # Get bearer token from service account key
+    # From https://github.com/broadinstitute/firecloud-tools/blob/master/scripts/register_service_account/register_service_account.py
+    scopes = ['https://www.googleapis.com/auth/userinfo.profile', 'https://www.googleapis.com/auth/userinfo.email']
+    credentials = ServiceAccountCredentials.from_json_keyfile_name(json_credentials, scopes=scopes)
+    headers = {"Authorization": "bearer " + credentials.get_access_token().access_token}
+    headers["User-Agent"] = firecloud_api.FISS_USER_AGENT
+
+    logging.info('Register service account in SAM')
+    sam_url = "https://sam.dsde-dev.broadinstitute.org"
+    requests.post(sam_url + "/register/user", headers=headers)
+
+    logging.info('Create new workflow-collection')
+    workflow_collection_url = "{}/api/resource/workflow-collection/{}".format(sam_url, workflow_collection_id)
+    requests.post(workflow_collection_url, headers=headers)
+
+    logging.info('Create group in firecloud')
+    firecloud_groups_url = "https://firecloud-orchestration.dsde-dev.broadinstitute.org/api/groups/{}".format(args.firecloud_group_name)
+    response = requests.post(firecloud_groups_url, headers=headers)
+    group_info = response.json()
+    group_email = group_info['membersGroup']['groupEmail']
+
+    logging.info('Add reader and writer policies to workflow collection')
+    reader_policy = {
+        "memberEmails": [
+        ],
+        "actions": [
+            "view"
+        ],
+        "roles": [
+            "reader"
+        ]
+    }
+    writer_policy = {
+        "memberEmails": [group_email],
+        "actions": [
+            "view",
+            "add",
+            "delete",
+            "abort"
+        ],
+        "roles": [
+            "writer"
+        ]
+    }
+    requests.put(workflow_collection_url + "/policies/reader", headers=headers, json=reader_policy)
+    requests.put(workflow_collection_url + "/policies/writer", headers=headers, json=writer_policy)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('json_credentials', help='Path to the json credentials file for this service account.')
+    parser.add_argument('workflow_collection_id', help='Name of the workflow-collection to create in SAM.')
+    parser.add_argument('firecloud_group_name', help='Name of the user group to create in FireCloud to control workflow-collection permissions.')
+    args = parser.parse_args()
+    register_service_account(args.json_credentials, args.workflow_collection_id)


### PR DESCRIPTION
These scripts set up the required user accounts for lira to talk to cromwell-as-a-service. It will: 
- Create a service account and key for a given gcloud project
- Add the key to vault
- Register a service account user in firecloud
- Register a service account user in SAM
- Create a workflow-collection resource in SAM
- Create a group in firecloud to manage permissions
- Add reader and writer policies to the collection, and add the firecloud user group to the writer policy