### PR TITLE
Use DCP central logging

### DIFF
--- a/kubernetes/create-logging-sink.sh
+++ b/kubernetes/create-logging-sink.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Creates a sink for exporting logs from Stackdriver.
+# Lira logs get sent to Stackdriver when running in Google Cloud Platform.
+# Creating the sink allows the logs to be exported automatically to a
+# Google Pub/Sub topic that feeds them into the DCP's central logging infrastructure.
+
+# Parameters
+
+# sink_name
+# An arbitrary identifier that serves to uniquely identify
+# a logging export sink within a Google Cloud Project (there could be several in a project).
+
+# destination
+# This tells Google where to send the logs.
+# Several kinds of destinations are supported by Google, but for integration with
+# DCP centralized logging, this must point to the Pub/Sub topic that the central
+# logging system is monitoring, of the form
+# pubsub.googleapis.com/projects/<logs_project_id>/topics/<topic_name>
+# logs_project_id and topic_name can be obtained from the DCP logging system administrator.
+
+sink_name=$1
+destination=$2
+
+error=0
+if [ -z $sink_name ]; then
+  printf "\nYou must provide a sink name\n"
+  error=1
+fi
+if [ -z $destination ]; then
+  printf "\nYou must provide a destination\n"
+  error=1
+fi
+if [ $error -eq 1 ]; then
+  printf "\nUsage: bash create-logging-sink.sh SINK_NAME DESTINATION\n\n"
+  exit 1
+fi
+
+printf "\nCreating log sink\n"
+gcloud -q logging sinks create $sink_name $destination
+
+printf "\nGetting email address associated with sink:\n"
+log_email=$(gcloud logging sinks describe $sink_name | grep writerIdentity | sed 's/writerIdentity:\ serviceAccount:\(.*\)/\1/g')
+
+printf "$log_email"
+printf "\n\nYou should send the above email address to an administrator of DCP central logging for registration.\n\n"

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -19,7 +19,7 @@ def post(body):
         return lira_utils.response_with_server_header(dict(error='Unauthorized'), 401)
 
     logger.info("Notification received")
-    logger.debug("Received notification body: {notification}".format(notification=body))
+    logger.info("Received notification body: {notification}".format(notification=body))
 
     # Get bundle uuid, version and subscription_id
     uuid, version, subscription_id = lira_utils.extract_uuid_version_subscription_id(body)
@@ -31,7 +31,7 @@ def post(body):
             dict(error='Not Found: No wdl config found with subscription id {}'
                        ''.format(subscription_id)), 404)
     wdl_config = id_matches[0]
-    logger.debug("Matched WDL config: {wdl}".format(wdl=wdl_config))
+    logger.info("Matched WDL config: {wdl}".format(wdl=wdl_config))
     logger.info("Preparing to launch {workflow_name} workflow in Cromwell".format(workflow_name=wdl_config.workflow_name))
 
     # Prepare inputs

--- a/lira/lira.py
+++ b/lira/lira.py
@@ -29,7 +29,16 @@ application = app.app
 config_path = os.environ['listener_config']
 logger.info('Using config file at {0}'.format(config_path))
 with open(config_path) as f:
-    app.app.config = lira_config.LiraConfig(json.load(f), app.app.config)
+    config = lira_config.LiraConfig(json.load(f), app.app.config)
+    app.app.config = config
+
+    # Configure log level for loggers that print query params.
+    # Unless specified otherwise in Lira's config file, these will be set
+    # at ERROR for werkzeug and INFO for connexion.decorators.validation
+    # in order to suppress messages that include query params.
+    logging.getLogger('werkzeug').setLevel(config.log_level_werkzeug)
+    logging.getLogger('connexion.decorators.validation').setLevel(config.log_level_connexion_validation)
+
     app.app.prepare_submission = notifications.create_prepare_submission_function(app.app.config.cache_wdls)
 
 resolver = RestyResolver('lira.api', collection_endpoint_name='list')

--- a/lira/lira_config.py
+++ b/lira/lira_config.py
@@ -103,8 +103,15 @@ class LiraConfig(Config):
     def __init__(self, config_object, *args, **kwargs):
         logger = logging.getLogger('Lira | {module_path}'.format(module_path=__name__))
 
-        # Default value that can be overridden
+        # Setting default values that can be overridden
         self.cache_wdls = True
+
+        # Setting the following log levels prevents log messages that
+        # print query params in the log.
+        # Werkzeug has INFO messages that log the url including query params of each request.
+        # The Connexion validator has DEBUG messages that do the same.
+        self.log_level_werkzeug = 'WARNING'
+        self.log_level_connexion_validation = 'INFO'
 
         # parse the wdls section
         wdl_configs = []

--- a/lira/test/test_config.py
+++ b/lira/test/test_config.py
@@ -65,7 +65,28 @@ class TestStartupVerification(unittest.TestCase):
         test_config = deepcopy(self.correct_test_config)
         test_config['cache_wdls'] = False
         config = lira_config.LiraConfig(test_config)
-        self.assertFalse(config.cache_wdls)
+
+    def test_werkzeug_logger_warning_by_default(self):
+        test_config = deepcopy(self.correct_test_config)
+        config = lira_config.LiraConfig(test_config)
+        self.assertEqual(config.log_level_werkzeug, 'WARNING')
+
+    def test_connexion_validation_logger_info_by_default(self):
+        test_config = deepcopy(self.correct_test_config)
+        config = lira_config.LiraConfig(test_config)
+        self.assertEqual(config.log_level_connexion_validation, 'INFO')
+
+    def test_werkzeug_logger_can_be_set_to_debug(self):
+        test_config = deepcopy(self.correct_test_config)
+        test_config['log_level_werkzeug'] = 'DEBUG'
+        config = lira_config.LiraConfig(test_config)
+        self.assertEqual(config.log_level_werkzeug, 'DEBUG')
+
+    def test_connexion_validation_can_be_set_to_debug(self):
+        test_config = deepcopy(self.correct_test_config)
+        test_config['log_level_connexion_validation'] = 'DEBUG'
+        config = lira_config.LiraConfig(test_config)
+        self.assertEqual(config.log_level_connexion_validation, 'DEBUG')
 
     def test_config_duplicate_wdl_raises_value_error(self):
 
@@ -81,15 +102,16 @@ class TestStartupVerification(unittest.TestCase):
     def test_lira_config_exposes_all_methods_requested_in_notifications(self):
         # test that the calls made in notifications refer to attributes that
         # LiraConfig exposes
-        test_config = lira_config.LiraConfig(self.correct_test_config)
+        test_config = deepcopy(self.correct_test_config)
+        config = lira_config.LiraConfig(test_config)
         requested_lira_attributes = [
             'notification_token', 'wdls', 'cromwell_url', 'cromwell_user',
             'cromwell_password', 'MAX_CONTENT_LENGTH']
         for attr in requested_lira_attributes:
-            self.assertTrue(hasattr(test_config, attr), 'missing attribute %s' % attr)
+            self.assertTrue(hasattr(config, attr), 'missing attribute %s' % attr)
 
         # get an example wdl to test
-        wdl = test_config.wdls[0]
+        wdl = config.wdls[0]
         requested_wdl_attributes = [
             'subscription_id', 'wdl_link', 'workflow_name', 'wdl_static_inputs_link',
             'options_link']


### PR DESCRIPTION
Adds script to set up DCP central logging and invokes it from main setup script.

Also, modify main setup script so that errors are printed for all missing parameters, not just the first missing one.

Suppress logs that print request query params.

See:
https://elastc.com/c/A9Q*9L4w/430-link-into-dcp-wide-logging-system