### PR TITLE
Add 10x query for v5 metadata bundles

### DIFF
--- a/scripts/v5_queries/10x-query.json
+++ b/scripts/v5_queries/10x-query.json
@@ -1,0 +1,44 @@
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match": {
+            "files.process_json.processes.content.biomaterial_collection.dissociation_process.dissociation_method": "10x_v2"
+          }
+        },
+        {
+          "match": {
+            "files.process_json.processes.content.library_construction_approach": "10x_v2"
+          }
+        },
+        {
+          "match": {
+            "files.biomaterial_json.biomaterials.content.biomaterial_core.ncbi_taxon_id": 9606
+          }
+        }
+      ],
+      "must_not": [
+        {
+          "match": {
+            "files.process_json.processes.content.process_type.text": "analysis"
+          }
+        },
+        {
+          "range": {
+            "files.biomaterial_json.biomaterials.content.biomaterial_core.ncbi_taxon_id": {
+              "lt": 9606
+            }
+          }
+        },
+        {
+          "range": {
+            "files.biomaterial_json.biomaterials.content.biomaterial_core.ncbi_taxon_id": {
+              "gt": 9606
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add query for 10x bundles that follows the v5 metadata schema: https://github.com/HumanCellAtlas/metadata-schema/tree/develop

Here is the query that matches v4.6.1 bundles for reference: https://github.com/HumanCellAtlas/lira/blob/master/scripts/v4_queries/10x-query.json