### PR TITLE
Make it possible to use stub submit wdl

### DIFF
--- a/kubernetes/listener-config.json.ctmpl
+++ b/kubernetes/listener-config.json.ctmpl
@@ -8,7 +8,7 @@
       "cromwell_user": "{{$cromwellSecrets.Data.cromwell_user}}",
       "env": "{{ env "ENV" }}",
       "notification_token": "{{$listenerSecret.Data.notification_token}}",
-      "submit_wdl": "{{ env "PIPELINE_TOOLS_PREFIX" }}/adapter_pipelines/submit.wdl",
+      "submit_wdl": "{{ env "PIPELINE_TOOLS_PREFIX" }}/adapter_pipelines/{{ env "SUBMIT_WDL_DIR" }}submit.wdl",
       "wdls": [
         {
           "analysis_wdls": [


### PR DESCRIPTION
See https://elastc.com/c/4btDIPv3/615-stub-submission-wdl

It needs the same name as the regular submit wdl so that it will work with existing adapter wdls without changes. (Existing adapter wdls import a file named submit.wdl.)