### PR TITLE
Enable Lira to add labels to workflows at start

### DIFF
--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -39,9 +39,12 @@ def post(body):
     cromwell_inputs_file = json.dumps(inputs)
 
     # Prepare labels
-    cromwell_labels = json.dumps(body.get('labels'))
-    if cromwell_labels:
-        logger.info("Will add labels: {labels} to the workflow after syntax validation".format(labels=cromwell_labels))
+    labels_from_notification = body.get('labels')
+    cromwell_labels = lira_utils.compose_labels(wdl_config.workflow_name, wdl_config.wdl_version, uuid, version,
+                                                labels_from_notification)
+    cromwell_labels_file = json.dumps(cromwell_labels)
+
+    logger.debug("Added labels {labels} to workflow".format(labels=cromwell_labels_file))
 
     cromwell_submission = current_app.prepare_submission(wdl_config, lira_config.submit_wdl)
     logger.info(current_app.prepare_submission.cache_info())
@@ -64,7 +67,8 @@ def post(body):
             url=lira_config.cromwell_url,
             user=lira_config.cromwell_user,
             password=lira_config.cromwell_password,
-            label=cromwell_labels
+            label=cromwell_labels_file,
+            validate_labels=False  # switch off the validators provided by cromwell_tools
         )
         if cromwell_response.status_code > 201:
             logger.error("HTTP error content: {content}".format(content=cromwell_response.text))

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -38,6 +38,11 @@ def post(body):
     inputs = lira_utils.compose_inputs(wdl_config.workflow_name, uuid, version, lira_config.env)
     cromwell_inputs_file = json.dumps(inputs)
 
+    # Prepare labels
+    cromwell_labels = json.dumps(body.get('labels'))
+    if cromwell_labels:
+        logger.info("Will add labels: {labels} to the workflow after syntax validation".format(labels=cromwell_labels))
+
     cromwell_submission = current_app.prepare_submission(wdl_config, lira_config.submit_wdl)
     logger.info(current_app.prepare_submission.cache_info())
 
@@ -58,7 +63,8 @@ def post(body):
             options_file=cromwell_submission.options_file,
             url=lira_config.cromwell_url,
             user=lira_config.cromwell_user,
-            password=lira_config.cromwell_password
+            password=lira_config.cromwell_password,
+            label=cromwell_labels
         )
         if cromwell_response.status_code > 201:
             logger.error("HTTP error content: {content}".format(content=cromwell_response.text))

--- a/lira/lira_config.py
+++ b/lira/lira_config.py
@@ -96,14 +96,32 @@ class WdlConfig(Config):
             raise TypeError('analysis_wdls must be a list')
 
     def __str__(self):
-        s = 'WdlConfig({0}, {1}, {2}, {3}, {4}, {5}, {6})'
-        return s.format(self.subscription_id, self.wdl_link, self.analysis_wdls,
-            self.workflow_name, self.wdl_static_inputs_link, self.options_link, self.wdl_version)
+        s = 'WdlConfig(subscription_id: {0},' \
+            ' wdl_link: {1},' \
+            ' analysis_wdls: {2},' \
+            ' workflow_name: {3},' \
+            ' wdl_static_inputs_link: {4},' \
+            ' options_link: {5},' \
+            ' wdl_version: {6})'
+        return s.format(
+            self.subscription_id,
+            self.wdl_link,
+            self.analysis_wdls,
+            self.workflow_name,
+            self.wdl_static_inputs_link,
+            self.options_link,
+            self.wdl_version)
 
     def __repr__(self):
         s = 'WdlConfig({0}, {1}, {2}, {3}, {4}, {5}, {6})'
-        return s.format(self.subscription_id, self.wdl_link, self.analysis_wdls,
-            self.workflow_name, self.wdl_static_inputs_link, self.options_link, self.wdl_version)
+        return s.format(
+            self.subscription_id,
+            self.wdl_link,
+            self.analysis_wdls,
+            self.workflow_name,
+            self.wdl_static_inputs_link,
+            self.options_link,
+            self.wdl_version)
 
 
 class LiraConfig(Config):
@@ -149,14 +167,14 @@ class LiraConfig(Config):
         # parse the wdls section
         wdl_configs = []
         try:
-            for wdl in config_object['wdls']:
+            for wdl in config_object['wdls']:  # Parse wdls and instantiate WdlConfig objects
                 wdl_configs.append(WdlConfig(lira_utils.merge_two_dicts(wdl,
                     {'wdl_version': lira_utils.parse_github_resource_url(wdl['analysis_wdls'][0]).version})
-                ))
+                ))  # Add wdl_version to wdlConfig objects by parsing each of the first URL of analysis_wdls
         except KeyError:
             raise ValueError('supplied config file must contain a "wdls" section.')
         self._verify_wdl_configs(wdl_configs)
-        config_object['wdls'] = wdl_configs
+        config_object['wdls'] = wdl_configs  # Store the WdlConfig objects back to wdls section
 
         if config_object.get('dry_run'):
             logger = logging.getLogger('{module_path}'.format(module_path=__name__))
@@ -191,16 +209,35 @@ class LiraConfig(Config):
                 'contents.')
 
     def __str__(self):
-        s = 'LiraConfig({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7})'
-        return s.format(self.env, self.submit_wdl, self.cromwell_url,
-            '(cromwell_user)', '(cromwell_password)', '(notification_token)',
-            self.MAX_CONTENT_LENGTH, self.wdls)
+        s = 'LiraConfig(environment: {0},' \
+            ' submit_wdl: {1},' \
+            ' cromwell_url: {2},' \
+            ' cromwell_user(Invisible): {3},' \
+            ' cromwell_password(Invisible): {4},' \
+            ' notification_token(Invisible): {5},' \
+            ' MAX_CONTENT_LENGTH: {6},' \
+            ' wdls: {7})'
+        return s.format(
+            self.env,
+            self.submit_wdl,
+            self.cromwell_url,
+            '(cromwell_user)',
+            '(cromwell_password)',
+            '(notification_token)',
+            self.MAX_CONTENT_LENGTH,
+            self.wdls)
 
     def __repr__(self):
         s = 'LiraConfig({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7})'
-        return s.format(self.env, self.submit_wdl, self.cromwell_url,
-            '(cromwell_user)', '(cromwell_password)', '(notification_token)',
-            self.MAX_CONTENT_LENGTH, self.wdls)
+        return s.format(
+            self.env,
+            self.submit_wdl,
+            self.cromwell_url,
+            '(cromwell_user)',
+            '(cromwell_password)',
+            '(notification_token)',
+            self.MAX_CONTENT_LENGTH,
+            self.wdls)
 
 
 class MaxLevelFilter(object):

--- a/lira/lira_config.py
+++ b/lira/lira_config.py
@@ -96,13 +96,7 @@ class WdlConfig(Config):
             raise TypeError('analysis_wdls must be a list')
 
     def __str__(self):
-        s = 'WdlConfig(subscription_id: {0},' \
-            ' wdl_link: {1},' \
-            ' analysis_wdls: {2},' \
-            ' workflow_name: {3},' \
-            ' wdl_static_inputs_link: {4},' \
-            ' options_link: {5},' \
-            ' wdl_version: {6})'
+        s = 'WdlConfig({0}, {1}, {2}, {3}, {4}, {5}, {6})'
         return s.format(
             self.subscription_id,
             self.wdl_link,
@@ -113,7 +107,13 @@ class WdlConfig(Config):
             self.wdl_version)
 
     def __repr__(self):
-        s = 'WdlConfig({0}, {1}, {2}, {3}, {4}, {5}, {6})'
+        s = 'WdlConfig(subscription_id: {0},' \
+            ' wdl_link: {1},' \
+            ' analysis_wdls: {2},' \
+            ' workflow_name: {3},' \
+            ' wdl_static_inputs_link: {4},' \
+            ' options_link: {5},' \
+            ' wdl_version: {6})'
         return s.format(
             self.subscription_id,
             self.wdl_link,
@@ -209,14 +209,7 @@ class LiraConfig(Config):
                 'contents.')
 
     def __str__(self):
-        s = 'LiraConfig(environment: {0},' \
-            ' submit_wdl: {1},' \
-            ' cromwell_url: {2},' \
-            ' cromwell_user(Invisible): {3},' \
-            ' cromwell_password(Invisible): {4},' \
-            ' notification_token(Invisible): {5},' \
-            ' MAX_CONTENT_LENGTH: {6},' \
-            ' wdls: {7})'
+        s = 'LiraConfig({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7})'
         return s.format(
             self.env,
             self.submit_wdl,
@@ -228,7 +221,14 @@ class LiraConfig(Config):
             self.wdls)
 
     def __repr__(self):
-        s = 'LiraConfig({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7})'
+        s = 'LiraConfig(environment: {0},' \
+            ' submit_wdl: {1},' \
+            ' cromwell_url: {2},' \
+            ' cromwell_user(Invisible): {3},' \
+            ' cromwell_password(Invisible): {4},' \
+            ' notification_token(Invisible): {5},' \
+            ' MAX_CONTENT_LENGTH: {6},' \
+            ' wdls: {7})'
         return s.format(
             self.env,
             self.submit_wdl,

--- a/lira/test/test_lira_utils.py
+++ b/lira/test/test_lira_utils.py
@@ -7,9 +7,15 @@ class TestUtils(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.valid_github_url = 'https://github.com/Organization/Repo/blob/master/lib/utils/util.py'
-        cls.valid_github_raw_url = 'https://raw.githubusercontent.com/User1/Repo/v0.3.4/lib/utils/util.py'
-        cls.invalid_github_url = 'https://github.com/User1/Repo.git'
+        cls.valid_github_url = 'https://github.com/HumanCellAtlas/pipeline-tools/blob/master/adapter_pipelines/' \
+                               'ss2_single_sample/adapter_example_static.json'
+        cls.valid_github_raw_url = 'https://github.com/HumanCellAtlas/skylab/blob/v0.3.0/pipelines/smartseq2_single_sample/ss2_single_sample.wdl'
+        cls.invalid_github_url = 'https://github.com/HumanCellAtlas/pipeline-tools.git'
+        cls.workflow_name = 'SmartSeq2Workflow'
+        cls.workflow_version = 'v0.0.1'
+        cls.bundle_uuid = 'foo-bar-id'
+        cls.bundle_version = '2018-01-01T10:10:10.384Z'
+        cls.extra_labels = {'Comment': 'Test'}
 
     def test_is_authenticated_no_auth_header(self):
         """Request without 'auth' key in header should not be treated as authenticated.
@@ -50,21 +56,54 @@ class TestUtils(unittest.TestCase):
 
     def test_parse_github_resource_url(self):
         """Test if parse_github_resource_url can correctly parse Github resource urls."""
-        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).repo, 'Repo')
-        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).owner, 'Organization')
-        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).version, 'master')
-        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).file, 'util.py')
-        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).path, 'lib/utils/util.py')
-        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).repo, 'Repo')
-        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).owner, 'User1')
-        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).version, 'v0.3.4')
-        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).file, 'util.py')
-        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).path, 'lib/utils/util.py')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).repo,
+                         'pipeline-tools')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).owner,
+                         'HumanCellAtlas')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).version,
+                         'master')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).file,
+                         'adapter_example_static.json')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).path,
+                         'adapter_pipelines/ss2_single_sample/adapter_example_static.json')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).repo,
+                         'skylab')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).owner,
+                         'HumanCellAtlas')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).version,
+                         'v0.3.0')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).file,
+                         'ss2_single_sample.wdl')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).path,
+                         'pipelines/smartseq2_single_sample/ss2_single_sample.wdl')
         self.assertRaises(ValueError, lira_utils.parse_github_resource_url, self.invalid_github_url)
 
     def test_merge_two_dicts(self):
         """Test if merge_two_dicts can correctly merge two dicts."""
         self.assertEqual(lira_utils.merge_two_dicts({'a': 1}, {'b': 2}), {'a': 1, 'b': 2})
+
+    def test_compose_labels_no_extra_labels(self):
+        """Test if compose_labels can correctly compose labels without extra labels."""
+        expected_labels = {
+            "workflow-name": 'smartseq2workflow',
+            "workflow-version": 'v0-0-1',
+            "bundle-uuid": 'foo-bar-id',
+            "bundle-version": '2018-01-01t10-10-10-384z'
+        }
+        self.assertEqual(lira_utils.compose_labels(
+            self.workflow_name, self.workflow_version, self.bundle_uuid, self.bundle_version), expected_labels)
+
+    def test_compose_labels_with_extra_labels(self):
+        """Test if compose_labels can correctly compose labels with extra labels."""
+        expected_labels = {
+            "workflow-name": 'smartseq2workflow',
+            "workflow-version": 'v0-0-1',
+            "bundle-uuid": 'foo-bar-id',
+            "bundle-version": '2018-01-01t10-10-10-384z',
+            "comment": 'test'
+        }
+        self.assertEqual(lira_utils.compose_labels(self.workflow_name, self.workflow_version, self.bundle_uuid,
+                                                   self.bundle_version, self.extra_labels), expected_labels)
 
 
 if __name__ == '__main__':

--- a/lira/test/test_lira_utils.py
+++ b/lira/test/test_lira_utils.py
@@ -5,6 +5,12 @@ from lira import lira_utils
 
 class TestUtils(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls.valid_github_url = 'https://github.com/Organization/Repo/blob/master/lib/utils/util.py'
+        cls.valid_github_raw_url = 'https://raw.githubusercontent.com/User1/Repo/v0.3.4/lib/utils/util.py'
+        cls.invalid_github_url = 'https://github.com/User1/Repo.git'
+
     def test_is_authenticated_no_auth_header(self):
         """Request without 'auth' key in header should not be treated as authenticated.
         """
@@ -41,6 +47,24 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(inputs['foo.bundle_uuid'], 'bar')
         self.assertEqual(inputs['foo.bundle_version'], 'baz')
         self.assertEqual(inputs['foo.runtime_environment'], 'asdf')
+
+    def test_parse_github_resource_url(self):
+        """Test if parse_github_resource_url can correctly parse Github resource urls."""
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).repo, 'Repo')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).owner, 'Organization')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).version, 'master')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).file, 'util.py')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_url).path, 'lib/utils/util.py')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).repo, 'Repo')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).owner, 'User1')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).version, 'v0.3.4')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).file, 'util.py')
+        self.assertEqual(lira_utils.parse_github_resource_url(self.valid_github_raw_url).path, 'lib/utils/util.py')
+        self.assertRaises(ValueError, lira_utils.parse_github_resource_url, self.invalid_github_url)
+
+    def test_merge_two_dicts(self):
+        """Test if merge_two_dicts can correctly merge two dicts."""
+        self.assertEqual(lira_utils.merge_two_dicts({'a': 1}, {'b': 2}), {'a': 1, 'b': 2})
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ google-cloud-storage
 flask
 gunicorn
 requests
-git+git://github.com/broadinstitute/cromwell-tools.git
+git+git://github.com/broadinstitute/cromwell-tools.git@v0.2.0
 git+git://github.com/HumanCellAtlas/pipeline-tools.git


### PR DESCRIPTION
This PR take advantages of another PR https://github.com/broadinstitute/cromwell-tools/pull/9 to enable Lira to add labels to workflows at the start. All of the labels should follow the Cromwell's rules, or the workflow will fail to start.

~~**Note:** to add what specific labels to workflow is not determined yet, this PR only focuses on adding the feature, determining sets of labels is out of scope.~~