### PR TITLE
Make use_caas value boolean

### DIFF
--- a/kubernetes/listener-config.json.ctmpl
+++ b/kubernetes/listener-config.json.ctmpl
@@ -13,7 +13,7 @@
       {{ end }}
       "version": "{{ env "LIRA_VERSION" }}",
       "MAX_CONTENT_LENGTH": 10000,
-      "use_caas": "{{ env "USE_CAAS" }}",
+      "use_caas": {{ env "USE_CAAS" | parseBool }},
       "env": "{{ env "ENV" }}",
       "notification_token": "{{$listenerSecret.Data.notification_token}}",
       "submit_wdl": "{{ env "PIPELINE_TOOLS_PREFIX" }}/adapter_pipelines/{{ env "SUBMIT_WDL_DIR" }}submit.wdl",


### PR DESCRIPTION
Remove the quotes around the `USE_CAAS` value in the listener-config template, so that it is a boolean value when it is rendered. Also use `parseBool` to convert "False", "false", 0, etc. to false.

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
