### PR TITLE
Fix the lira service unstable issue

### DIFF
--- a/kubernetes/listener-deployment.yaml.ctmpl
+++ b/kubernetes/listener-deployment.yaml.ctmpl
@@ -12,6 +12,7 @@ spec:
       containers:
       - name: listener
         image: quay.io/humancellatlas/secondary-analysis-lira:{{env "DOCKER_TAG"}}
+        imagePullPolicy: Always
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -1,11 +1,11 @@
 import connexion
 import json
 import logging
-import os
 import time
 from flask import current_app
 from cromwell_tools import cromwell_tools
 from lira import lira_utils
+
 
 logger = logging.getLogger("{module_path}".format(module_path=__name__))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ connexion==1.4
 google-auth==1.4.1
 google-cloud-storage==1.8.0
 flask==0.12.2
-gunicorn==19.7.1
+gunicorn==19.8.1
+gevent==1.3.1
 requests==2.18.4
 requests-mock==1.4.0
 oauth2client==4.1.2

--- a/start_lira.sh
+++ b/start_lira.sh
@@ -10,4 +10,5 @@ if [ -z $port ]; then
     port=8080
 fi
 
-gunicorn lira.lira:app -b 0.0.0.0:$port
+# Having too small number for the timeout argument can cause Gunicorn run into CRITICAL worker timeout problems
+gunicorn lira.lira:app -b 0.0.0.0:$port --timeout 120

--- a/start_lira.sh
+++ b/start_lira.sh
@@ -11,4 +11,4 @@ if [ -z $port ]; then
 fi
 
 # Having too small number for the timeout argument can cause Gunicorn run into CRITICAL worker timeout problems
-gunicorn lira.lira:app -b 0.0.0.0:$port --timeout 120
+gunicorn lira.lira:app -b 0.0.0.0:$port --timeout 120 --workers $((2 * $(getconf _NPROCESSORS_ONLN) + 1))

--- a/start_lira.sh
+++ b/start_lira.sh
@@ -10,5 +10,20 @@ if [ -z $port ]; then
     port=8080
 fi
 
-# Having too small number for the timeout argument can cause Gunicorn run into CRITICAL worker timeout problems
-gunicorn lira.lira:app -b 0.0.0.0:$port --timeout 120 --workers $((2 * $(getconf _NPROCESSORS_ONLN) + 1))
+#--workers: by default, it's set to 1, which is not enough, especially with sync workers, which means any of long
+#   requests will break/block the main process and cause CRITICAL TIMEOUTS problems.
+#   Now it's set to 2*AVAILABLE_CPU_CORES_OF_THE_CURRENT_MACHINE + 1, according to the suggestion of the gunicorn doc.
+#--timeout: by default, it's set to 30s, which is not enough for some of the requests that are sent to Cromwell.
+#   It's set to 60 seconds now, which is consistent with the response timeout(NOT the health check timeout) of
+#   our GKE Load Balancer.
+#--graceful-timeout: by default, it's set to 30s, this parameter helps the workers reboot gracefully,
+#   instead of shutting down immediately. It's set to 60s now to be consistent with the timeouts.
+#--worker-class: this is the critical parameter that controls the working pattern of gunicorn server.
+#   According to its doc, we should use async workers so that those time-consuming requests won't block the worker.
+#   It's set to gevent now, since the other async choice for us, gthread workers, are suitable for CPU bound tasks,
+#   instead of I/O bound tasks in our case.
+gunicorn lira.lira:app -b 0.0.0.0:$port \
+    --workers $((2 * $(getconf _NPROCESSORS_ONLN) + 1)) \
+    --timeout 60 \
+    --graceful-timeout 60 \
+    --worker-class gevent


### PR DESCRIPTION
This is related to the ticket: https://elastc.com/c/gc7LiNIh/736-lira-service-unstable-issue

After some debugging, the root cause of this issue might be: since now both GCE load balancer and AWS Route53 Health Checker is hitting the `/health` endpoint of Lira, sometimes there will be some traffics there to wait for being processed, which will take more than 30 secs, but since Gunicorn's default timeout is just 30 secs, it will cause the **CRITICAL worker timeout** problem. The current solution is to increase the Gunicorn timeout to 120 secs, in this feature branch, and deploy that Lira to our dev environment, observe how it works for a while, tweak the parameter as it goes. SO this will become a recurring ticket, may be or not be closed within this sprint. 

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [x] Considered generalizability beyond our own use case

----
**Now the it seems the `CRITICAL TIMEOUTS` has gone.** 

## Gunicorn
After doing some further researches, the original issue was because we didn't set any of the following parameters for Gunicorn:
- `--workers`: by default, it's set to 1, which is not enough, let alone we combined it with `sync` workers, which means any of long requests will break/block the main process and cause `CRITICAL TIMEOUTS` problems. Now it's set to 2*CPU_CORES+1, according to the suggestion of the official doc.
- `--timeout`: by default, it is set to 30s, which is not enough for some of the requests that are sent to Cromwell. It is set to 60 seconds now, which is consistent with the response timeout(NOT the health check timeout) of our GKE Load Balancer. 
- `--graceful-timeout`: this will help the workers reboot gracefully, instead of shutting down immediately. It is set to 60s now to be consistent with the timeouts.
- `--worker-class`: this is the critical parameter that we missed before. According to the [Gunicorn Doc](http://docs.gunicorn.org/en/latest/design.html#async-workers), we should change to use `async` workers, so that not only the throughput can increase, but also those rare longer requests won't block the worker(we used `sync` worker) completely which caused `CRITICAL TIMEOUTS` previously. It is set to `gevent`, since the other choice of us, `gthread` workers are suitable for CPU bound tasks, instead of I/O bound tasks in our case.

## GCE Load Balancer
Currently the only way to modify the request timeout for the LB is to do it manually through GCP console for each deployment. There are discussion about doing this programmatcially https://github.com/kubernetes/kubernetes/issues/32273 and https://github.com/kubernetes/ingress-nginx/issues/243 . We should follow up those streams, and hopefully we could set the timeouts in our ingress/servce YAML file soon.

## Kubernetes Deployment
I also added `imagePullPolicy` to our deployment YAML file to get rid of some random issues caused by cached docker images on GKE/GCE, based on the information [here](https://kubernetes.io/docs/concepts/containers/images/) and our experience with JMUI.

## Future works
We need to find a way to parameterize the configs of the Gunicorn, so each time we have to fine-tune the numbers, we don't neet to go back here to change the code base and rebuild the docker image.