### PR TITLE
Add option to include additional metadata in notifications

### DIFF
--- a/scripts/subscription-create.py
+++ b/scripts/subscription-create.py
@@ -6,16 +6,24 @@ from httplib2 import Http
 from oauth2client.service_account import ServiceAccountCredentials
 
 
-def prep_json(callback_base_url, listener_secret, query_json):
-    js = {}
-    js["callback_url"] = "{0}?auth={1}".format(callback_base_url, listener_secret)
-
-    query = None
-    with open(query_json) as f:
+def prep_json(callback_base_url, listener_secret, query_json_file, attachments_file=None):
+    query = {}
+    with open(query_json_file) as f:
         query = json.load(f)
-    js["es_query"] = query
 
-    return js
+    payload = {
+        'es_query': query,
+        'callback_url': '{0}?auth={1}'.format(callback_base_url, listener_secret)
+    }
+
+    if attachments_file:
+        attachments = {}
+        with open(attachments_file) as f:
+            attachments = json.load(f)
+        payload['attachments'] = attachments
+
+    return payload
+
 
 def make_request(js, dss_url, key_file):
     scopes = ['https://www.googleapis.com/auth/userinfo.email']
@@ -25,6 +33,7 @@ def make_request(js, dss_url, key_file):
     response, content = h.request(dss_url, 'PUT', body=json.dumps(js), headers=headers)
     print(content)
 
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("dss_url", help='Endpoint for creating new subscriptions in the storage service')
@@ -32,6 +41,9 @@ if __name__ == '__main__':
     parser.add_argument("listener_secret", help='Auth key for listener')
     parser.add_argument("key_file", help='JSON file containing storage service credentials')
     parser.add_argument("query_json", help='JSON file containing the query to register')
+    parser.add_argument("--additional_metadata",
+                        required=False,
+                        help='JSON file with additional fields to include in the notification')
     args = parser.parse_args()
-    js = prep_json(args.callback_base_url, args.listener_secret, args.query_json)
+    js = prep_json(args.callback_base_url, args.listener_secret, args.query_json, args.additional_metadata)
     make_request(js, args.dss_url, args.key_file)

--- a/scripts/subscription-create.py
+++ b/scripts/subscription-create.py
@@ -7,7 +7,6 @@ from oauth2client.service_account import ServiceAccountCredentials
 
 
 def prep_json(callback_base_url, listener_secret, query_json_file, attachments_file=None):
-    query = {}
     with open(query_json_file) as f:
         query = json.load(f)
 
@@ -17,7 +16,6 @@ def prep_json(callback_base_url, listener_secret, query_json_file, attachments_f
     }
 
     if attachments_file:
-        attachments = {}
         with open(attachments_file) as f:
             attachments = json.load(f)
         payload['attachments'] = attachments

--- a/scripts/subscription-create.sh
+++ b/scripts/subscription-create.sh
@@ -8,7 +8,7 @@ query_json=$5
 additional_metadata=$6
 
 if [ $additional_metadata ]; then
-    ./subscription-create.py "$dss_url?replica=gcp" $green_url $listener_secret $key_file $query_json --additional_metadata $additional_metadata
-else
-    ./subscription-create.py "$dss_url?replica=gcp" $green_url $listener_secret $key_file $query_json
+    additional_metadata_flag="--additional_metadata"
 fi
+
+./subscription-create.py "$dss_url?replica=gcp" $green_url $listener_secret $key_file $query_json $additional_metadata_flag $additional_metadata

--- a/scripts/subscription-create.sh
+++ b/scripts/subscription-create.sh
@@ -5,5 +5,10 @@ green_url=$2
 key_file=$3
 listener_secret=$4
 query_json=$5
+additional_metadata=$6
 
-./subscription-create.py "$dss_url?replica=gcp" $green_url $listener_secret $key_file $query_json
+if [ $additional_metadata ]; then
+    ./subscription-create.py "$dss_url?replica=gcp" $green_url $listener_secret $key_file $query_json --additional_metadata $additional_metadata
+else
+    ./subscription-create.py "$dss_url?replica=gcp" $green_url $listener_secret $key_file $query_json
+fi

--- a/scripts/v5_queries/metadata_attachments.json
+++ b/scripts/v5_queries/metadata_attachments.json
@@ -1,0 +1,14 @@
+{
+  "project_shortname": {
+    "type": "jmespath",
+    "expression": "files.project_json.content.project_core.project_shortname"
+  },
+  "submitter_id": {
+    "type": "jmespath",
+    "expression": "files.project_json.hca_ingest.submitter_id"
+  },
+  "sample_id": {
+    "type": "jmespath",
+    "expression": "files.links_json.links[?source_type=='biomaterial' && destination_type=='sequencing_process'].source_id"
+  }
+}


### PR DESCRIPTION
Add option to include additional metadata fields in the notification when creating a subscription to the data store. The script will optionally take in a JSON file containing information about which fields to include, where "expression" is using [JMESpath](http://jmespath.org/) syntax to specify the value of the property. Example JSON format from the DSS API:  
```
{
    "additionalProp1": {
      "type": "jmespath", 
      "expression": "string"
    },
    "additionalProp2": {
      "type": "jmespath", 
      "expression": "string"
    }
}
```
This is passed in as the value of the "attachments" key in the JSON payload sent to the `/subscriptions` endpoint. Here is the API spec for additional context: https://github.com/HumanCellAtlas/data-store/blob/1a7a28db83c767aee4da7a93daaea5cad484d8c1/dss-api.yml#L486


The notification body will now have an additional "attachments" key with the additional metadata fields, e.g:
```
    'attachments': {
        'sample_id': ['sample_1'],
        'submitter_id': None, 
        'project_shortname': 'Q4_DEMO-project_PRJNA248302'
    }
```

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [x] Updated documentation
- [ ] Applied style guidelines
- [x] Considered generalizability beyond our own use case
