### PR TITLE
Add submit_and_hold flag

### DIFF
--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -82,6 +82,7 @@ def post(body):
             url=lira_config.cromwell_url,
             label=cromwell_labels_file,
             validate_labels=False,  # switch off the validators provided by cromwell_tools
+            on_hold=lira_config.submit_and_hold,
             **auth
         )
         if cromwell_response.status_code > 201:

--- a/lira/lira_config.py
+++ b/lira/lira_config.py
@@ -138,6 +138,7 @@ class LiraConfig(Config):
     def __init__(self, config_object, *args, **kwargs):
         # Setting default values that can be overridden
         self.cache_wdls = True
+        self.submit_and_hold = False
 
         # Setting the following log levels prevents log messages that
         # print query params in the log.

--- a/lira/test/test_config.py
+++ b/lira/test/test_config.py
@@ -57,6 +57,17 @@ class TestStartupVerification(unittest.TestCase):
         with self.assertRaises(TypeError):
             lira_config.LiraConfig(test_config)
 
+    def test_submit_and_hold_is_false_by_default(self):
+        test_config = deepcopy(self.correct_test_config)
+        config = lira_config.LiraConfig(test_config)
+        self.assertFalse(config.submit_and_hold)
+
+    def test_submit_and_hold_can_be_set_to_true(self):
+        test_config = deepcopy(self.correct_test_config)
+        test_config['submit_and_hold'] = True
+        config = lira_config.LiraConfig(test_config)
+        self.assertTrue(config.submit_and_hold)
+
     def test_cache_wdls_is_true_by_default(self):
         test_config = deepcopy(self.correct_test_config)
         config = lira_config.LiraConfig(test_config)
@@ -66,6 +77,7 @@ class TestStartupVerification(unittest.TestCase):
         test_config = deepcopy(self.correct_test_config)
         test_config['cache_wdls'] = False
         config = lira_config.LiraConfig(test_config)
+        self.assertFalse(config.cache_wdls)
 
     def test_werkzeug_logger_warning_by_default(self):
         test_config = deepcopy(self.correct_test_config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ requests==2.18.4
 requests-mock==1.4.0
 oauth2client==4.1.2
 mock==2.0.0
-git+git://github.com/broadinstitute/cromwell-tools.git@72f2ac955afdb70b25144ff64f4177d0261deb97
+git+git://github.com/broadinstitute/cromwell-tools.git@v0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ requests==2.18.4
 requests-mock==1.4.0
 oauth2client==4.1.2
 mock==2.0.0
-git+git://github.com/broadinstitute/cromwell-tools.git@v0.3.1
+git+git://github.com/broadinstitute/cromwell-tools.git@72f2ac955afdb70b25144ff64f4177d0261deb97


### PR DESCRIPTION
Add flag to configure whether the workflows started by Lira should be set to "On Hold" status by default. By default, the `submit_and_hold` flag is set to false. 

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
