### PR TITLE
Set max_cromwell_retries in workflow inputs (790)

### DIFF
--- a/kubernetes/listener-config.json.ctmpl
+++ b/kubernetes/listener-config.json.ctmpl
@@ -25,6 +25,7 @@
     {{ else }}
       "notification_token": "{{$listenerSecret.Data.notification_token}}",
     {{ end }}
+      "max_cromwell_retries": 0,
       "submit_wdl": "{{ env "PIPELINE_TOOLS_PREFIX" }}/adapter_pipelines/{{ env "SUBMIT_WDL_DIR" }}submit.wdl",
       "wdls": [
         {

--- a/lira/lira_config.py
+++ b/lira/lira_config.py
@@ -213,6 +213,8 @@ class LiraConfig(Config):
         # If a notification's Date header is too old, we will refuse to accept it, configured by stale_notification_timeout.
         config_object['stale_notification_timeout'] = config_object.get('stale_notification_timeout', 0)
 
+        config_object['max_cromwell_retries'] = config_object.get('max_cromwell_retries', 0)
+
         Config.__init__(self, config_object, *args, **kwargs)
 
     @property

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -154,7 +154,8 @@ def compose_inputs(workflow_name, uuid, version, lira_config):
         workflow_name + '.runtime_environment': lira_config.env,
         workflow_name + '.dss_url': lira_config.dss_url,
         workflow_name + '.submit_url': lira_config.ingest_url,
-        workflow_name + '.use_caas': lira_config.use_caas
+        workflow_name + '.use_caas': lira_config.use_caas,
+        workflow_name + '.max_cromwell_retries': lira_config.max_cromwell_retries
     }
 
 

--- a/lira/test/test_config.py
+++ b/lira/test/test_config.py
@@ -211,6 +211,17 @@ class TestStartupVerification(unittest.TestCase):
         config = lira_config.LiraConfig(test_config)
         self.assertEqual(config.collection_name, 'fake-collection-name')
 
+    def test_max_cromwell_retries_defaults_to_zero(self):
+        test_config = deepcopy(self.correct_test_config)
+        config = lira_config.LiraConfig(test_config)
+        self.assertEqual(config.max_cromwell_retries, 0)
+
+    def test_max_cromwell_retries_can_be_set(self):
+        test_config = deepcopy(self.correct_test_config)
+        test_config['max_cromwell_retries'] = 12
+        config = lira_config.LiraConfig(test_config)
+        self.assertEqual(config.max_cromwell_retries, 12)
+
     def test_config_duplicate_wdl_raises_value_error(self):
 
         def add_duplicate_wdl_definition():


### PR DESCRIPTION
See https://elastc.com/c/dkauyyIF/790-make-ss2-have-cromwell-retries
and related PRs
https://github.com/HumanCellAtlas/skylab/pull/114
https://github.com/HumanCellAtlas/pipeline-tools/pull/51

- [x] Added or updated tests
- [ ] Updated documentation
- [x] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
