### PR TITLE
Fix a bug in lira_utils

### DIFF
--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -244,7 +244,7 @@ def legalize_cromwell_labels(label):
     length limitation of 255. This function will subset the first 255 characters for too long string values.
 
     Args:
-        label (str | list): A string or a list of a string of key/value of labels need to be legalized.
+        label (str | list | None): A string or a list of a string of key/value of labels need to be legalized.
 
     Returns:
         str: A string of label with no more than 255 characters.
@@ -259,7 +259,7 @@ def legalize_cromwell_labels(label):
         if len(label) != 1:
             raise ValueError('{} should contain exactly one element!'.format(label))
         label = label[0]
-    return label[:cromwell_label_maximum_length]
+    return str(label)[:cromwell_label_maximum_length]
 
 
 def compose_labels(workflow_name, workflow_version, bundle_uuid, bundle_version, *extra_labels):

--- a/lira/test/notification.json
+++ b/lira/test/notification.json
@@ -62,7 +62,7 @@
    "transaction_id": "9d0eb75c-d950-4e62-b685-4f20c8569410",
    "subscription_id": "222",
    "attachments": {
-      "submitter_id": "None",
+      "submitter_id": null,
       "sample_id": [
          "b1829a9d-6678-493b-bf98-01520f9bad52"
       ],

--- a/lira/test/test_lira_utils.py
+++ b/lira/test/test_lira_utils.py
@@ -67,7 +67,7 @@ class TestUtils(unittest.TestCase):
         cls.list_label = {'list_label': ['test']}
         cls.invalid_list_label = {'list_label': ['test', 'test2']}
         cls.attachments = {
-            'submitter_id': 'None',
+            'submitter_id': None,
             'sample_id': [
               'b1829a9d-6678-493b-bf98-01520f9bad52'
             ],


### PR DESCRIPTION
Fix a bug that attachments field is None in notification body can break Lira.

Please ensure the following when opening a PR:
- [x] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
