### PR TITLE
Exclude results bundles in subscription query

### DIFF
--- a/scripts/v6_queries/10x-query.json
+++ b/scripts/v6_queries/10x-query.json
@@ -21,7 +21,7 @@
       "must_not": [
         {
           "match": {
-            "files.protocol_json.protocols.content.protocol_type.text": "analysis"
+            "files.process_json.processes.content.protocol_type.text": "analysis"
           }
         },
         {

--- a/scripts/v6_queries/smartseq2-query.json
+++ b/scripts/v6_queries/smartseq2-query.json
@@ -34,7 +34,7 @@
       "must_not": [
         {
           "match": {
-            "files.protocol_json.protocols.content.protocol_type.text": "analysis"
+            "files.process_json.processes.content.protocol_type.text": "analysis"
           }
         }, 
         {


### PR DESCRIPTION
Update subscription queries to exclude results bundles. This will likely change since most of the fields that are currently in the analysis protocol file vary based on the pipeline run and should belong in an analysis process file.

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
