### PR TITLE
Make HCA schema_url configurable

### DIFF
--- a/kubernetes/listener-config.json.ctmpl
+++ b/kubernetes/listener-config.json.ctmpl
@@ -19,6 +19,11 @@
       "use_caas": {{ env "USE_CAAS" | parseBool }},
       "env": "{{$environment}}",
       "dss_url": "https://dss.{{ if eq $environment "test" }}integration{{ else }}{{$environment}}{{ end }}.data.humancellatlas.org/v1",
+      {{ if eq $environment "prod" }}
+        "schema_url": "https://schema.humancellatlas.org/",
+      {{ else }}
+        "schema_url": "http://schema.{{ if eq $environment "test" }}integration{{ else }}{{$environment}}{{ end }}.data.humancellatlas.org/",
+      {{ end }}
       "ingest_url": "http://api.ingest.{{ if eq $environment "test" }}integration{{ else }}{{$environment}}{{ end }}.data.humancellatlas.org/",
     {{ if env "USE_HMAC" | parseBool }}
       "hmac_key": "{{$hmac_keys.Data.current_key}}",

--- a/kubernetes/listener-config.json.ctmpl
+++ b/kubernetes/listener-config.json.ctmpl
@@ -22,7 +22,7 @@
       {{ if eq $environment "prod" }}
         "schema_url": "https://schema.humancellatlas.org/",
       {{ else }}
-        "schema_url": "http://schema.{{ if eq $environment "test" }}integration{{ else }}{{$environment}}{{ end }}.data.humancellatlas.org/",
+        "schema_url": "http://schema.{{ if (or (eq $environment "test") (eq $environment "dev")) }}integration{{ else }}{{$environment}}{{ end }}.data.humancellatlas.org/",
       {{ end }}
       "ingest_url": "http://api.ingest.{{ if eq $environment "test" }}integration{{ else }}{{$environment}}{{ end }}.data.humancellatlas.org/",
     {{ if env "USE_HMAC" | parseBool }}

--- a/lira/lira_config.py
+++ b/lira/lira_config.py
@@ -229,7 +229,8 @@ class LiraConfig(Config):
             'wdls',
             'version',
             'dss_url',
-            'ingest_url'
+            'ingest_url',
+            'schema_url'
         }
 
     @staticmethod
@@ -256,7 +257,9 @@ class LiraConfig(Config):
             self.wdls,
             self.version,
             self.dss_url,
-            self.ingest_url)
+            self.ingest_url,
+            self.schema_url
+        )
 
     def __repr__(self):
         s = 'LiraConfig(environment: {0},' \
@@ -267,7 +270,8 @@ class LiraConfig(Config):
             ' wdls: {5},' \
             ' lira_version: {6}' \
             ' dss_url: {7}' \
-            ' ingest_url: {8})'
+            ' ingest_url: {8}' \
+            ' schema_url: {9}'
         return s.format(
             self.env,
             self.submit_wdl,
@@ -277,7 +281,9 @@ class LiraConfig(Config):
             self.wdls,
             self.version,
             self.dss_url,
-            self.ingest_url)
+            self.ingest_url,
+            self.schema_url
+        )
 
 
 class MaxLevelFilter(object):

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -170,6 +170,7 @@ def compose_inputs(workflow_name, uuid, version, lira_config):
         workflow_name + '.runtime_environment': lira_config.env,
         workflow_name + '.dss_url': lira_config.dss_url,
         workflow_name + '.submit_url': lira_config.ingest_url,
+        workflow_name + '.schema_url': lira_config.schema_url,
         workflow_name + '.use_caas': lira_config.use_caas,
         workflow_name + '.max_cromwell_retries': lira_config.max_cromwell_retries
     }

--- a/lira/test/data/config.json
+++ b/lira/test/data/config.json
@@ -10,6 +10,7 @@
   "MAX_CONTENT_LENGTH": 10000,
   "dss_url": "https://dss.dev.data.humancellatlas.org/v1",
   "ingest_url": "http://api.ingest.dev.data.humancellatlas.org/",
+  "schema_url": "https://schema.humancellatlas.org",
   "submit_wdl": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/v0.1.5/adapter_pipelines/submit.wdl",
   "wdls": [
     {


### PR DESCRIPTION
Now that there are different environments for the HCA metadata schemas, make the url configurable in Lira. This parameter will get included in the pipeline inputs JSON file that gets passed to Cromwell.

Note: The environment to use for the metadata schema url will match the Lira environment: e.g. integration Lira will use `http://schema.integration.data.humancellatlas.org/` and staging Lira will use `http://schema.staging.data.humancellatlas.org/`. 

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
