### PR TITLE
Scripts to disconnect and reconnect greenbox (the "big red button")

### DIFF
--- a/kubernetes/abort_workflows.py
+++ b/kubernetes/abort_workflows.py
@@ -10,7 +10,7 @@ def get_workflows(cromwell_url, query_dict, caas_key):
     return workflows
 
 
-def abort_workflows(cromwell_url, workflows, caas_key, dry_run=True):
+def abort_workflows(cromwell_url, workflows, caas_key, dry_run=False):
     auth, headers = cromwell_tools._get_auth_credentials(caas_key=caas_key)
     logging.info('Aborting {} workflows in {}'.format(len(workflows), cromwell_url))
     for workflow in workflows:
@@ -28,10 +28,11 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--cromwell_url')
     parser.add_argument('--caas_key')
-    parser.add_argument('--dry_run', default=True)
+    parser.add_argument('--dry_run', default='false')
     args = parser.parse_args()
     query_dict = {
         'status': ['On Hold', 'Running']
     }
+    dry_run = True if args.dry_run.lower() == 'true' else False
     target_workflows = get_workflows(args.cromwell_url, query_dict, args.caas_key)
-    abort_workflows(args.cromwell_url, target_workflows, args.caas_key, dry_run=args.dry_run)
+    abort_workflows(args.cromwell_url, target_workflows, args.caas_key, dry_run=dry_run)

--- a/kubernetes/abort_workflows.py
+++ b/kubernetes/abort_workflows.py
@@ -1,0 +1,37 @@
+import argparse
+import logging
+import requests
+from cromwell_tools import cromwell_tools
+
+
+def get_workflows(cromwell_url, query_dict, caas_key):
+    response = cromwell_tools.query_workflows(cromwell_url, query_dict, caas_key=caas_key)
+    workflows = response.json()['results']
+    return workflows
+
+
+def abort_workflows(cromwell_url, workflows, caas_key, dry_run=True):
+    auth, headers = cromwell_tools._get_auth_credentials(caas_key=caas_key)
+    logging.info('Aborting {} workflows in {}'.format(len(workflows), cromwell_url))
+    for workflow in workflows:
+        workflow_id = workflow['id']
+        abort_url = '{}/api/workflows/v1/{}/abort'.format(cromwell_url, workflow_id)
+        if not dry_run:
+            response = requests.post(abort_url, auth=auth, headers=headers)
+            if response.status_code != 200:
+                logging.info('Could not abort workflow {}'.format(workflow_id))
+        logging.info('Aborted workflow {}'.format(workflow_id))
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--cromwell_url')
+    parser.add_argument('--caas_key')
+    parser.add_argument('--dry_run', default=True)
+    args = parser.parse_args()
+    query_dict = {
+        'status': ['On Hold', 'Running']
+    }
+    target_workflows = get_workflows(args.cromwell_url, query_dict, args.caas_key)
+    abort_workflows(args.cromwell_url, target_workflows, args.caas_key, dry_run=args.dry_run)

--- a/kubernetes/start_greenbox.sh
+++ b/kubernetes/start_greenbox.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Restart greenbox services after running "stop_greenbox.sh"
+# This script will re-create the Lira ingress and Falcon deployment to resume running analysis workflows
+
+KUBE_CONTEXT=$1
+VAULT_TOKEN_FILE=${VAULT_TOKEN_FILE:-"$HOME/.vault-token"}
+
+if [ -z $KUBE_CONTEXT ]; then
+    echo -e "\nYou must specify a Kubernetes context to use"
+    error=1
+fi
+
+if [ $error -eq 1 ]; then
+    echo -e "\nUsage: bash start_greenbox.sh KUBE_CONTEXT \n"
+    exit 1
+fi
+
+kubectl config use-context ${KUBE_CONTEXT}
+
+# Get latest TLS secret
+TLS_SECRET_NAME=$(kubectl get secrets -o json | jq -c '[.items[] | select(.metadata.name | contains("tls-secret"))][-1]' | jq -r .metadata.name)
+
+echo "Re-create Lira ingress"
+docker run -i --rm -e TLS_SECRET_NAME=${TLS_SECRET_NAME} -v ${VAULT_TOKEN_FILE}:/root/.vault-token -v ${PWD}:/working broadinstitute/dsde-toolbox:k8s /usr/local/bin/render-ctmpl.sh -k /working/listener-ingress.yaml.ctmpl
+
+kubectl create -f listener-ingress.yaml --record --save-config
+
+# TODO: Uncomment when Falcon is deployed
+#echo "Re-create Falcon deployment"

--- a/kubernetes/stop_greenbox.sh
+++ b/kubernetes/stop_greenbox.sh
@@ -6,6 +6,7 @@
 KUBE_CONTEXT=$1
 CROMWELL_URL=$2
 VAULT_ENV=$3
+DRY_RUN=$4
 VAULT_TOKEN_FILE=${VAULT_TOKEN_FILE:-"$HOME/.vault-token"}
 
 if [ -z $KUBE_CONTEXT ]; then
@@ -17,24 +18,28 @@ elif [ -z $CROMWELL_URL ]; then
 elif [ -z $VAULT_ENV ]; then
     echo -e "\nYou must specify a vault environment for getting the CaaS service account key"
     error=1
+elif [ -z $DRY_RUN ]; then
+    DRY_RUN = "false"
 fi
-
 if [ $error -eq 1 ]; then
     echo -e "\nUsage: bash stop_greenbox.sh KUBE_CONTEXT CROMWELL_URL VAULT_ENV\n"
     exit 1
 fi
 
-
 kubectl config use-context ${KUBE_CONTEXT}
 
 # Delete ingress rule for Lira to stop receiving notifications
 echo "Delete Lira ingress"
-kubectl delete ingress listener
+if [ $DRY_RUN == "false" ]; then
+    kubectl delete ingress listener
+fi
 
 # Bring down Falcon to stop releasing workflows
 # TODO: Uncomment when Falcon is deployed
-#echo "Delete Falcon deployment"
-#kubectl delete deployment falcon
+# echo "Delete Falcon deployment"
+# if [ $DRY_RUN == 'false' ]; then
+# kubectl delete deployment falcon
+# fi
 
 CAAS_KEY_FILE="caas_key.json"
 docker run -i --rm -e VAULT_TOKEN=$(cat $VAULT_TOKEN_FILE) broadinstitute/dsde-toolbox vault read \
@@ -43,4 +48,4 @@ docker run -i --rm -e VAULT_TOKEN=$(cat $VAULT_TOKEN_FILE) broadinstitute/dsde-t
         secret/dsde/mint/$VAULT_ENV/listener/caas-${VAULT_ENV}-key.json > $CAAS_KEY_FILE
 
 # Abort all on-hold and running workflows
-python -m abort_workflows --cromwell_url ${CROMWELL_URL} --caas_key ${CAAS_KEY_FILE}
+python -m abort_workflows --cromwell_url ${CROMWELL_URL} --caas_key ${CAAS_KEY_FILE} --dry_run ${DRY_RUN}

--- a/kubernetes/stop_greenbox.sh
+++ b/kubernetes/stop_greenbox.sh
@@ -43,4 +43,4 @@ docker run -i --rm -e VAULT_TOKEN=$(cat $VAULT_TOKEN_FILE) broadinstitute/dsde-t
         secret/dsde/mint/$VAULT_ENV/listener/caas-${VAULT_ENV}-key.json > $CAAS_KEY_FILE
 
 # Abort all on-hold and running workflows
- python -m abort_workflows --cromwell_url ${CROMWELL_URL} --caas_key ${CAAS_KEY_FILE}
+python -m abort_workflows --cromwell_url ${CROMWELL_URL} --caas_key ${CAAS_KEY_FILE}

--- a/kubernetes/stop_greenbox.sh
+++ b/kubernetes/stop_greenbox.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# WARNING: This script stops all greenbox services and workflows.
+# Example usage: bash stop_greenbox.sh gke_dev_context https://example-cromwell.org/api/workflows/v1 dev
+
+KUBE_CONTEXT=$1
+CROMWELL_URL=$2
+VAULT_ENV=$3
+VAULT_TOKEN_FILE=${VAULT_TOKEN_FILE:-"$HOME/.vault-token"}
+
+if [ -z $KUBE_CONTEXT ]; then
+    echo -e "\nYou must specify a Kubernetes context to use"
+    error=1
+elif [ -z $CROMWELL_URL ]; then
+    echo -e "\nYou must specify a Cromwell url"
+    error=1
+elif [ -z $VAULT_ENV ]; then
+    echo -e "\nYou must specify a vault environment for getting the CaaS service account key"
+    error=1
+fi
+
+if [ $error -eq 1 ]; then
+    echo -e "\nUsage: bash stop_greenbox.sh KUBE_CONTEXT CROMWELL_URL VAULT_ENV\n"
+    exit 1
+fi
+
+
+kubectl config use-context ${KUBE_CONTEXT}
+
+# Delete ingress rule for Lira to stop receiving notifications
+echo "Delete Lira ingress"
+kubectl delete ingress listener
+
+# Bring down Falcon to stop releasing workflows
+# TODO: Uncomment when Falcon is deployed
+#echo "Delete Falcon deployment"
+#kubectl delete deployment falcon
+
+CAAS_KEY_FILE="caas_key.json"
+docker run -i --rm -e VAULT_TOKEN=$(cat $VAULT_TOKEN_FILE) broadinstitute/dsde-toolbox vault read \
+        -format=json \
+        -field=value \
+        secret/dsde/mint/$VAULT_ENV/listener/caas-${VAULT_ENV}-key.json > $CAAS_KEY_FILE
+
+# Abort all on-hold and running workflows
+ python -m abort_workflows --cromwell_url ${CROMWELL_URL} --caas_key ${CAAS_KEY_FILE}


### PR DESCRIPTION
The `stop_greenbox.sh`script: 
- disconnects Lira by deleting the ingress rule so that it cannot receive notifications at `pipelines.<env>.data.humancellatlas.org`
- deletes the falcon deployment to stop releasing on-hold workflows
- aborts all on-hold and running workflows 

The `start_greenbox.sh` script:
- recreates the ingress rule for Lira (this takes 5-10 minutes)
- recreates the falcon deployment 

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [x] Updated documentation
- [x] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
