### PR TITLE
Add cromwell_url as a input parameter to adapter workflows.

### DIFF
--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -172,7 +172,8 @@ def compose_inputs(workflow_name, uuid, version, lira_config):
         workflow_name + '.submit_url': lira_config.ingest_url,
         workflow_name + '.schema_url': lira_config.schema_url,
         workflow_name + '.use_caas': lira_config.use_caas,
-        workflow_name + '.max_cromwell_retries': lira_config.max_cromwell_retries
+        workflow_name + '.max_cromwell_retries': lira_config.max_cromwell_retries,
+        workflow_name + '.cromwell_url': lira_config.cromwell_url
     }
 
 

--- a/lira/test/test_lira_utils.py
+++ b/lira/test/test_lira_utils.py
@@ -340,6 +340,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(inputs['foo.dss_url'], 'https://dss.dev.data.humancellatlas.org/v1')
         self.assertEqual(inputs['foo.submit_url'], 'http://api.ingest.dev.data.humancellatlas.org/')
         self.assertEqual(inputs['foo.use_caas'], False)
+        self.assertEqual(inputs['foo.cromwell_url'], 'https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1')
 
     def test_compose_caas_options(self):
         test_config = deepcopy(self.correct_test_config)


### PR DESCRIPTION
This PR adds `cromwell_url` as an input parameter to be passed into the adapter workflows that Lira starts.

Please ensure the following when opening a PR:
- [X] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
