### PR TITLE
Updating requests lib in requirements.txt to fix security issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ google-cloud-storage==1.9.0
 flask>=1.0.0
 gunicorn==19.8.1
 gevent==1.3.4
-requests==2.18.4
+requests==2.20.0
 requests-mock==1.5.0
 oauth2client==4.1.2
 mock==2.0.0


### PR DESCRIPTION
Updating the requests lib in the requirements.txt file to address a security issue which was reported to us by GitHub. For more information: 

CVE-2018-18074 More information
moderate severity
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.
