### PR TITLE
Authenticate VMs with service account

### DIFF
--- a/lira/lira_config.py
+++ b/lira/lira_config.py
@@ -175,7 +175,7 @@ class LiraConfig(Config):
         logging.getLogger('connexion.decorators.validation').setLevel(self.log_level_connexion_validation)
 
         # Check cromwell credentials
-        use_caas = config_object.get('use_caas')
+        use_caas = config_object.get('use_caas', None)
         if not use_caas:
             config_object['use_caas'] = False
         if config_object.get('use_caas'):
@@ -224,7 +224,6 @@ class LiraConfig(Config):
             'env',
             'submit_wdl',
             'cromwell_url',
-            'use_caas',
             'MAX_CONTENT_LENGTH',
             'wdls',
             'version',

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -180,6 +180,9 @@ def compose_inputs(workflow_name, uuid, version, lira_config):
 def compose_caas_options(cromwell_options_file, lira_config):
     """ Append options for using Cromwell-as-a-service to the default options.json file in the wdl config.
 
+    Note: These options only work with Cromwell instances that use the Google Cloud Backend and allow
+    user-service-account authentication, such as Cromwell.
+
     Args:
         cromwell_options_file (str): Contents of the options.json file in the wdl config.
         lira_config (LiraConfig): Lira configuration.
@@ -193,12 +196,13 @@ def compose_caas_options(cromwell_options_file, lira_config):
     options_json = json.loads(options_file)
 
     with open(lira_config.caas_key) as f:
-        caas_key = f.read()
+        caas_key_json = json.loads(f.read())
+
     options_json.update({
         'jes_gcs_root': lira_config.gcs_root,
         'google_project': lira_config.google_project,
-        'user_service_account_json': caas_key,
-        'google_compute_service_account': "caas-prod-account-for-test@broad-dsde-mint-test.iam.gserviceaccount.com"
+        'user_service_account_json': caas_key_json,
+        'google_compute_service_account': caas_key_json['client_email']
     })
     return options_json
 

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -198,7 +198,7 @@ def compose_caas_options(cromwell_options_file, lira_config):
         'jes_gcs_root': lira_config.gcs_root,
         'google_project': lira_config.google_project,
         'user_service_account_json': caas_key,
-        'google_compute_service_account': caas_key
+        'google_compute_service_account': "caas-prod-account-for-test@broad-dsde-mint-test.iam.gserviceaccount.com"
     })
     return options_json
 

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -197,7 +197,8 @@ def compose_caas_options(cromwell_options_file, lira_config):
     options_json.update({
         'jes_gcs_root': lira_config.gcs_root,
         'google_project': lira_config.google_project,
-        'user_service_account_json': caas_key
+        'user_service_account_json': caas_key,
+        'google_compute_service_account': caas_key
     })
     return options_json
 

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -171,7 +171,6 @@ def compose_inputs(workflow_name, uuid, version, lira_config):
         workflow_name + '.dss_url': lira_config.dss_url,
         workflow_name + '.submit_url': lira_config.ingest_url,
         workflow_name + '.schema_url': lira_config.schema_url,
-        workflow_name + '.use_caas': lira_config.use_caas,
         workflow_name + '.max_cromwell_retries': lira_config.max_cromwell_retries,
         workflow_name + '.cromwell_url': lira_config.cromwell_url
     }

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -196,12 +196,13 @@ def compose_caas_options(cromwell_options_file, lira_config):
     options_json = json.loads(options_file)
 
     with open(lira_config.caas_key) as f:
-        caas_key_json = json.loads(f.read())
+        caas_key = f.read()
+        caas_key_json = json.loads(caas_key)
 
     options_json.update({
         'jes_gcs_root': lira_config.gcs_root,
         'google_project': lira_config.google_project,
-        'user_service_account_json': caas_key_json,
+        'user_service_account_json': caas_key,
         'google_compute_service_account': caas_key_json['client_email']
     })
     return options_json

--- a/lira/test/data/fake_caas_key.json
+++ b/lira/test/data/fake_caas_key.json
@@ -1,3 +1,4 @@
 {
-  "msg": "This file is deliberately empty"
+  "client_email": "test-account-project_id.iam.gserviceaccount.com",
+  "msg": "The rest of the fields in this test key have been intentionally cleared."
 }

--- a/lira/test/test_lira_utils.py
+++ b/lira/test/test_lira_utils.py
@@ -354,7 +354,9 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(options['google_project'], 'fake_google_project')
         with open('data/fake_caas_key.json') as f:
             fake_caas_key = f.read()
+            fake_caas_key_json = json.loads(fake_caas_key)
         self.assertEqual(options['user_service_account_json'], fake_caas_key)
+        self.assertEqual(options['google_compute_service_account'], fake_caas_key_json['client_email'])
 
     def test_parse_github_resource_url(self):
         """Test if parse_github_resource_url can correctly parse Github resource urls."""

--- a/lira/test/test_lira_utils.py
+++ b/lira/test/test_lira_utils.py
@@ -339,7 +339,6 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(inputs['foo.runtime_environment'], 'dev')
         self.assertEqual(inputs['foo.dss_url'], 'https://dss.dev.data.humancellatlas.org/v1')
         self.assertEqual(inputs['foo.submit_url'], 'https://api.ingest.dev.data.humancellatlas.org/')
-        self.assertEqual(inputs['foo.use_caas'], False)
         self.assertEqual(inputs['foo.cromwell_url'], 'https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1')
 
     def test_compose_caas_options(self):


### PR DESCRIPTION
### Purpose
Fixes https://app.zenhub.com/workspaces/dcp-backlogs-5ac7bcf9465cb172b77760d9/issues/humancellatlas/secondary-analysis/450

---
### Changes
Makes the VMs started by Cromwell authenticate as the CAAS service account, which is required for generating a bearer token to send requests to CAAS without having to pass in a key file.

---
### Review Instructions
Check that the service account in a VM is the CAAS service account by getting the `jobId` of a task from the metadata and doing `gcloud alpha genomics operations describe <jobId>` 

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [x] This PR added or updated tests.
- [x] This PR updated docstrings or documentation.
- [x] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [x] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
Note: I left the `use_caas` key in the config file for Lira in case there is a workflow that we want to run in Cromwell that requires a username/pw in the future