### PR TITLE
Add project_uuid to the metadata attachment in subscriptions.

### DIFF
--- a/scripts/vx_queries/metadata_attachments.json
+++ b/scripts/vx_queries/metadata_attachments.json
@@ -6,6 +6,9 @@
   "sample_id": {
     "type": "jmespath",
     "expression": "files.links_json[].links[?input_type=='biomaterial' && protocols[?protocol_type=='sequencing_protocol']].inputs[][]"
-
+  },
+  "project_uuid": {
+    "type": "jmespath",
+    "expression": "files.project_json[].provenance.document_id | [0]"
   }
 }


### PR DESCRIPTION
### Purpose
_Please explain the purpose of this PR and include links to any GitHub issues that it fixes:_

- https://app.zenhub.com/workspaces/dcp-backlogs-5ac7bcf9465cb172b77760d9/issues/humancellatlas/secondary-analysis/484
---
### Changes
_Please list out what major changes were made in this PR to address the issue:_

- Add a new field `project_uuid` to the `metadata_attachments.json` which is used to make subscriptions. This will tells DSS to send `project_uuid` when notifying the subscribed Lira.
---
### Review Instructions
_Please provide instructions about how should a reviewer test/verify the changes in this PR:_

- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
