### PR TITLE
Specify compute service account

### DIFF
--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -197,7 +197,8 @@ def compose_caas_options(cromwell_options_file, lira_config):
     options_json.update({
         'jes_gcs_root': lira_config.gcs_root,
         'google_project': lira_config.google_project,
-        'user_service_account_json': caas_key
+        'user_service_account_json': caas_key,
+        'google_compute_service_account': json.loads(caas_key)['client_email']
     })
     return options_json
 


### PR DESCRIPTION
### Purpose
Use the CaaS service account as the 'google_compute_service_account' in the workflow options so that the VMs use the CaaS service account instead of the default compute engine SA. 

This change is required to generate credentials (bearer token or jwt) from the service account without having to pass in the key file to the Cromwell task.

---

### Changes

Add CaaS service account as the 'google_compute_service_account' in the workflow options

---

### Review Instructions
_Please provide instructions about how should a reviewer test/verify the changes in this PR:_

- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
