### PR TITLE
Include CAAS key path in workflow inputs

### DIFF
--- a/deploy/config_files/config.sh.ctmpl
+++ b/deploy/config_files/config.sh.ctmpl
@@ -18,6 +18,7 @@
     export TENX_VERSION="cellranger_v1.0.2"
 
     export GCLOUD_PROJECT="broad-dsde-mint-${LIRA_ENVIRONMENT}" # all valid envs - broad-dsde-mint-dev, broad-dsde-mint-test, broad-dsde-mint-integration, broad-dsde-mint-staging, hca-dcp-pipelines-prod
+    export SERVICE_ACCOUNT_KEY_PATH="gs://broad-dsde-mint-dev-credentials/caas_key.json"
 
     export DSS_URL="https://dss.integration.data.humancellatlas.org/v1"
     export SCHEMA_URL="https://schema.integration.data.humancellatlas.org/"
@@ -41,6 +42,7 @@
     export TENX_VERSION="cellranger_v1.0.2"
 
     export GCLOUD_PROJECT="broad-dsde-mint-${LIRA_ENVIRONMENT}"
+    export SERVICE_ACCOUNT_KEY_PATH="gs://broad-dsde-mint-test-credentials/caas_key.json"
 
     export DSS_URL="https://dss.integration.data.humancellatlas.org/v1"
     export SCHEMA_URL="https://schema.integration.data.humancellatlas.org/"
@@ -64,6 +66,7 @@
     export TENX_VERSION="cellranger_v1.0.2"
 
     export GCLOUD_PROJECT="broad-dsde-mint-${LIRA_ENVIRONMENT}"
+    export SERVICE_ACCOUNT_KEY_PATH="gs://broad-dsde-mint-staging-credentials/caas_key.json"
 
     export DSS_URL="https://dss.staging.data.humancellatlas.org/v1"
     export SCHEMA_URL="https://schema.staging.data.humancellatlas.org/"
@@ -87,6 +90,7 @@
     export TENX_VERSION="cellranger_v1.0.2"
 
     export GCLOUD_PROJECT="hca-dcp-pipelines-prod"
+    export SERVICE_ACCOUNT_KEY_PATH="gs://broad-dsde-mint-prod-credentials/caas_key.json"
 
     export DSS_URL="https://dss.data.humancellatlas.org/v1"
     export SCHEMA_URL="https://schema.humancellatlas.org/"

--- a/deploy/config_files/lira-config.json.ctmpl
+++ b/deploy/config_files/lira-config.json.ctmpl
@@ -21,6 +21,7 @@
     "dss_url": "{{ env "DSS_URL" }}",
     "schema_url": "{{ env "SCHEMA_URL" }}",
     "ingest_url": "{{ env "INGEST_URL" }}",
+    "service_account_key_path": "{{ env "SERVICE_ACCOUNT_KEY_PATH" }}"
 {{ if env "USE_HMAC" | parseBool }}
     "hmac_key": "{{ $hmac_keys.Data.current_key }}",
 {{ else }}

--- a/deploy/config_files/lira-config.json.ctmpl
+++ b/deploy/config_files/lira-config.json.ctmpl
@@ -21,7 +21,7 @@
     "dss_url": "{{ env "DSS_URL" }}",
     "schema_url": "{{ env "SCHEMA_URL" }}",
     "ingest_url": "{{ env "INGEST_URL" }}",
-    "service_account_key_path": "{{ env "SERVICE_ACCOUNT_KEY_PATH" }}"
+    "service_account_key_path": "{{ env "SERVICE_ACCOUNT_KEY_PATH" }}",
 {{ if env "USE_HMAC" | parseBool }}
     "hmac_key": "{{ $hmac_keys.Data.current_key }}",
 {{ else }}

--- a/deploy/jenkins/deploy_lira.sh
+++ b/deploy/jenkins/deploy_lira.sh
@@ -114,6 +114,7 @@ docker run -i --rm \
               -e SUBMIT_AND_HOLD="${SUBMIT_AND_HOLD}" \
               -e COLLECTION_NAME="${COLLECTION_NAME}" \
               -e GCLOUD_PROJECT="${GCLOUD_PROJECT}" \
+              -e SERVICE_ACCOUNT_KEY_PATH="{SERVICE_ACCOUNT_KEY_PATH}" \
               -e GCS_ROOT="${GCS_ROOT}" \
               -e LIRA_VERSION="${LIRA_VERSION}" \
               -e DSS_URL="${DSS_URL}" \

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -164,6 +164,7 @@ def compose_inputs(workflow_name, uuid, version, lira_config):
     Returns:
         dict: A dictionary of workflow inputs.
     """
+
     return {
         workflow_name + '.bundle_uuid': uuid,
         workflow_name + '.bundle_version': version,
@@ -173,7 +174,8 @@ def compose_inputs(workflow_name, uuid, version, lira_config):
         workflow_name + '.schema_url': lira_config.schema_url,
         workflow_name + '.use_caas': lira_config.use_caas,
         workflow_name + '.max_cromwell_retries': lira_config.max_cromwell_retries,
-        workflow_name + '.cromwell_url': lira_config.cromwell_url
+        workflow_name + '.cromwell_url': lira_config.cromwell_url,
+        workflow_name + '.service_account_key_path': lira_config.service_account_key_path
     }
 
 

--- a/lira/test/data/config.json
+++ b/lira/test/data/config.json
@@ -12,6 +12,7 @@
   "ingest_url": "https://api.ingest.dev.data.humancellatlas.org/",
   "schema_url": "https://schema.humancellatlas.org",
   "submit_wdl": "https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/v0.1.5/adapter_pipelines/submit.wdl",
+  "service_account_key_path": "gs://bucket-with-credentials/caas_key.json",
   "wdls": [
     {
       "subscription_id": "3e3e176b-629f-46ea-b01d-e36bd650dc54",

--- a/lira/test/test_lira_utils.py
+++ b/lira/test/test_lira_utils.py
@@ -341,6 +341,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(inputs['foo.submit_url'], 'https://api.ingest.dev.data.humancellatlas.org/')
         self.assertEqual(inputs['foo.use_caas'], False)
         self.assertEqual(inputs['foo.cromwell_url'], 'https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1')
+        self.assertEqual(inputs['foo.service_account_key_path'], 'gs://bucket-with-credentials/caas_key.json')
 
     def test_compose_caas_options(self):
         test_config = deepcopy(self.correct_test_config)


### PR DESCRIPTION
### Purpose
Tasks in the submission WDL that make API requests to ingest need to generate a JWT from the CaaS service account key. 

Since the path to where the key is stored will vary depending on the environment, this PR adds a `service_account_key_path` variable to the Lira config file, which gets passed in as a workflow input.

---
### Changes
- The environment-specific inputs file that Lira creates for each workflow includes the `service_account_key_path` from the Lira config

---
### Review Instructions

- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
