### PR TITLE
Update Lira config for dev and int

### DIFF
--- a/deploy/config_files/config.sh.ctmpl
+++ b/deploy/config_files/config.sh.ctmpl
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 {{with $ENVIRONMENT := env "LIRA_ENVIRONMENT"}}
 {{ if eq $ENVIRONMENT "dev" }}
-    export LIRA_VERSION="v0.16.0"
+    export LIRA_VERSION="v0.17.0"
 
-    export PIPELINE_TOOLS_VERSION="v0.44.0"
+    export PIPELINE_TOOLS_VERSION="v0.46.0"
 
     export NUMBER_OF_REPLICAS="3"
 
@@ -26,9 +26,9 @@
 {{end}}
 
 {{if (or (eq $ENVIRONMENT "test") (eq $ENVIRONMENT "integration")) }}
-    export LIRA_VERSION="v0.16.0"
+    export LIRA_VERSION="v0.17.0"
 
-    export PIPELINE_TOOLS_VERSION="v0.44.0"
+    export PIPELINE_TOOLS_VERSION="v0.46.0"
 
     export NUMBER_OF_REPLICAS="3"
 


### PR DESCRIPTION
### Purpose
Deploy to dev and integration environment.

---
### Changes
Lira:
Authenticate Cromwell VMs with the Cromwell-as-a-Service (CaaS) service account by using the "google_compute_service_account" workflow options parameter

Pipeline-tools:
- Use the default application credentials of the VM when requesting metadata from Cromwell instead of storing the JSON key in a private docker image
- Use JWT created from CaaS service account for authentication to Ingest API

---
### Review Instructions

- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
