### PR TITLE
Make query for 10xv2 data more specific

### DIFF
--- a/scripts/vx_queries/10x-query.json
+++ b/scripts/vx_queries/10x-query.json
@@ -4,7 +4,7 @@
       "must": [
         {
           "match": {
-            "files.library_preparation_protocol_json.library_construction_approach.ontology": "EFO:0009310"
+            "files.library_preparation_protocol_json.library_construction_approach.ontology_label": "10X v2 sequencing"
           }
         },
         {
@@ -26,7 +26,7 @@
       "must_not": [
         {
           "match": {
-            "files.sequencing_protocol_json.sequencing_approach.ontology": "EFO:0009294"
+            "files.sequencing_protocol_json.sequencing_approach.ontology_label": "CITE-seq"
           }
         },
         {

--- a/scripts/vx_queries/10x-query.json
+++ b/scripts/vx_queries/10x-query.json
@@ -5,7 +5,16 @@
         {
           "match": {
             "files.library_preparation_protocol_json.library_construction_approach.ontology": "EFO:0009310"
-
+          }
+        },
+        {
+          "match": {
+            "files.library_preparation_protocol_json.end_bias": "3 prime tag"
+          }
+        },
+        {
+          "match": {
+            "files.library_preparation_protocol_json.nucleic_acid_source": "single cell"
           }
         },
         {
@@ -15,6 +24,11 @@
         }
       ],
       "must_not": [
+        {
+          "match": {
+            "files.sequencing_protocol_json.sequencing_approach.ontology": "EFO:0009294"
+          }
+        },
         {
           "match": {
             "files.analysis_process_json.process_type.text": "analysis"
@@ -38,4 +52,3 @@
     }
   }
 }
-


### PR DESCRIPTION
### Purpose
Make the query for 10xv2 data more specific so that secondary analysis only receives notifications for data that can be processed by the Cellranger and Optimus pipelines.

---
### Changes
Update the query to get only single cell data with a 3 prime tag end bias and exclude anything from CITEseq assays.

---
### Review Instructions
Should there be a single `sequencing_approach.ontology` that the query matches on, or should the query just exclude CITEseq data?

The 10xv2 datasets in production have various values for the `sequencing_approach.ontology` field. For example, the Peer dataset is using `EFO:0008995 (10x sequencing)` and the fetal/maternal interface dataset is using `EFO:0008440 (Tag based single cell RNA sequencing)`. Both have been analyzed by the Cellranger pipeline.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
- No follow-up discussions.
