### PR TITLE
Fix the bug caused by restrictive validations against API models.

### DIFF
--- a/lira/lira_api.yml
+++ b/lira/lira_api.yml
@@ -91,7 +91,7 @@ definitions:
       match:
         $ref: '#/definitions/Match'
       attachments:
-          $ref: '#/definitions/SingleSampleIdAttachments'
+          $ref: '#/definitions/MultipleSampleIdAttachments'
       subscription_id:
         type: string
         description: "Subscription UUID correspdoning to this notification"
@@ -122,17 +122,6 @@ definitions:
     required:
       - bundle_uuid
       - bundle_version
-  SingleSampleIdAttachments:
-    type: object
-    properties:
-      sample_id:
-        type: string
-        format: uuid
-      project_shortname:
-        type: string
-      project_uuid:
-        type: string
-        format: uuid
   MultipleSampleIdAttachments:
     type: object
     properties:


### PR DESCRIPTION
### Purpose
_Please explain the purpose of this PR and include links to any GitHub issues that it fixes:_

- The strict validation of the Connexion app caused a bug that prevents Lira from processing notifications that have list as `sample_id`s in the notification body. This PR should address that.
---
### Changes
_Please list out what major changes were made in this PR to address the issue:_

- No changes.
---
### Review Instructions
_Please provide instructions about how should a reviewer test/verify the changes in this PR:_

- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
