### PR TITLE
GH-60: Use latest version of cromwell-tools

### DIFF
--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -3,11 +3,8 @@ import json
 import logging
 import time
 import io
-import os
+import cromwell_tools
 from flask import current_app
-from cromwell_tools.cromwell_api import CromwellAPI
-from cromwell_tools.cromwell_auth import CromwellAuth
-from cromwell_tools import utilities as cromwell_utils
 from lira import lira_utils
 
 
@@ -71,25 +68,25 @@ def post(body):
             options = lira_utils.compose_caas_options(cromwell_submission.options_file, lira_config)
             options_file = json.dumps(options).encode('utf-8')
 
-            auth = CromwellAuth.harmonize_credentials(
+            auth = cromwell_tools.cromwell_auth.CromwellAuth.harmonize_credentials(
                 url=lira_config.cromwell_url,
-                service_account_key=os.environ['caas_key']
+                service_account_key=lira_config.caas_key
             )
             kwargs['collection_name'] = lira_config.collection_name
         else:
             options_file = cromwell_submission.options_file
-            auth = CromwellAuth.harmonize_credentials(
+            auth = cromwell_tools.cromwell_auth.CromwellAuth.harmonize_credentials(
                 url=lira_config.cromwell_url,
                 username=lira_config.cromwell_user,
                 password=lira_config.cromwell_password
             )
 
-        cromwell_response = CromwellAPI.submit(
+        cromwell_response = cromwell_tools.cromwell_api.CromwellAPI.submit(
             auth=auth,
             wdl_file=io.BytesIO(cromwell_submission.wdl_file),
             inputs_files=[io.BytesIO(cromwell_inputs), io.BytesIO(cromwell_submission.wdl_static_inputs_file)],
             options_file=io.BytesIO(options_file),
-            dependencies=cromwell_utils.make_zip_in_memory(cromwell_submission.wdl_deps_dict),
+            dependencies=cromwell_tools.utilities.make_zip_in_memory(cromwell_submission.wdl_deps_dict),
             label_file=io.BytesIO(cromwell_labels_file),
             on_hold=lira_config.submit_and_hold,
             validate_labels=False,  # switch off the validators provided by cromwell_tools

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -52,6 +52,7 @@ def post(body):
 
     logger.debug("Added labels {labels} to workflow".format(labels=cromwell_labels_file))
 
+    logger.info("Preparing workflow submission...")
     cromwell_submission = current_app.prepare_submission(wdl_config, lira_config.submit_wdl)
     logger.info(current_app.prepare_submission.cache_info())
 
@@ -82,6 +83,7 @@ def post(body):
                 password=lira_config.cromwell_password
             )
 
+        logger.info('Launching workflow...')
         cromwell_response = CromwellAPI.submit(
             auth=auth,
             wdl_file=io.BytesIO(cromwell_submission.wdl_file),

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -2,7 +2,6 @@
 """
 import json
 import logging
-from cromwell_tools import utilities as cromwell_utils
 from flask import make_response
 from urllib.parse import urlparse
 from collections import namedtuple
@@ -11,6 +10,7 @@ import hashlib
 import base64
 import email.utils
 from datetime import datetime, timedelta, timezone
+import cromwell_tools
 
 
 logger = logging.getLogger('lira.{module_path}'.format(module_path=__name__))
@@ -347,12 +347,12 @@ def create_prepare_submission_function(cache_wdls):
         """Load into memory all static data needed for submitting a workflow to Cromwell"""
 
         # Read files into memory
-        wdl_file = cromwell_utils.download(wdl_config.wdl_link)
-        wdl_static_inputs_file = cromwell_utils.download(wdl_config.wdl_static_inputs_link)
-        options_file = cromwell_utils.download(wdl_config.options_link)
+        wdl_file = cromwell_tools.utilities.download(wdl_config.wdl_link)
+        wdl_static_inputs_file = cromwell_tools.utilities.download(wdl_config.wdl_static_inputs_link)
+        options_file = cromwell_tools.utilities.download(wdl_config.options_link)
 
         # Create zip of analysis and submit wdls
-        url_to_contents = cromwell_utils.download_to_map(wdl_config.analysis_wdls + [submit_wdl])
+        url_to_contents = cromwell_tools.utilities.download_to_map(wdl_config.analysis_wdls + [submit_wdl])
         wdl_deps_dict = url_to_contents
 
         return CromwellSubmission(wdl_file, wdl_static_inputs_file, options_file, wdl_deps_dict)

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -2,7 +2,7 @@
 """
 import json
 import logging
-from cromwell_tools import cromwell_tools
+from cromwell_tools import utilities as cromwell_utils
 from flask import make_response
 from urllib.parse import urlparse
 from collections import namedtuple
@@ -347,12 +347,12 @@ def create_prepare_submission_function(cache_wdls):
         """Load into memory all static data needed for submitting a workflow to Cromwell"""
 
         # Read files into memory
-        wdl_file = cromwell_tools.download(wdl_config.wdl_link)
-        wdl_static_inputs_file = cromwell_tools.download(wdl_config.wdl_static_inputs_link)
-        options_file = cromwell_tools.download(wdl_config.options_link)
+        wdl_file = cromwell_utils.download(wdl_config.wdl_link)
+        wdl_static_inputs_file = cromwell_utils.download(wdl_config.wdl_static_inputs_link)
+        options_file = cromwell_utils.download(wdl_config.options_link)
 
         # Create zip of analysis and submit wdls
-        url_to_contents = cromwell_tools.download_to_map(wdl_config.analysis_wdls + [submit_wdl])
+        url_to_contents = cromwell_utils.download_to_map(wdl_config.analysis_wdls + [submit_wdl])
         wdl_deps_dict = url_to_contents
 
         return CromwellSubmission(wdl_file, wdl_static_inputs_file, options_file, wdl_deps_dict)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ requests-mock==1.5.0
 oauth2client==4.1.2
 mock==2.0.0
 requests-http-signature==v0.0.3
-git+git://github.com/broadinstitute/cromwell-tools.git@v0.4.0
+git+git://github.com/broadinstitute/cromwell-tools.git@v1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ requests-mock==1.5.0
 oauth2client==4.1.2
 mock==2.0.0
 requests-http-signature==v0.0.3
-git+git://github.com/broadinstitute/cromwell-tools.git@v1.1.1
+cromwell-tools==v1.1.1


### PR DESCRIPTION
### Purpose
Update to use the newest version of Cromwell tools. The latest submit function no longer has automated retries, which should prevent us from accidentally starting duplicate workflows off of the same notification.

Addresses ticket: https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530?selectedIssue=GH-60

---
### Changes

Update from cromwell-tools v0.4.0 --> v1.1.1

---
### Review Instructions
- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
- No follow-up discussions.
