### PR TITLE
Update field name in subscriptions

### DIFF
--- a/scripts/vx_queries/10x-query.json
+++ b/scripts/vx_queries/10x-query.json
@@ -4,7 +4,7 @@
       "must": [
         {
           "match": {
-            "files.library_preparation_protocol_json.library_construction_approach.ontology_label": "10X v2 sequencing"
+            "files.library_preparation_protocol_json.library_construction_method.ontology_label": "10X v2 sequencing"
           }
         },
         {

--- a/scripts/vx_queries/smartseq2-query.json
+++ b/scripts/vx_queries/smartseq2-query.json
@@ -4,7 +4,7 @@
       "must": [
         {
           "match": {
-            "files.library_preparation_protocol_json.library_construction_approach.ontology": "EFO:0008931"
+            "files.library_preparation_protocol_json.library_construction_method.ontology": "EFO:0008931"
 
           }
         },


### PR DESCRIPTION
### Purpose
Addresses ticket https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530?selectedIssue=GH-72

---
### Changes
Change `library_construction_approach` field to `library_construction_method` to correspond to schema change: https://github.com/HumanCellAtlas/metadata-schema/blob/3a5ffe9c2e0afc1bf111cb5d17733514c400d7fa/json_schema/type/protocol/sequencing/library_preparation_protocol.json#L72

---
### Review Instructions
- Confirm that the new field name is correct according to the schema in develop: https://github.com/HumanCellAtlas/metadata-schema/blob/develop/json_schema/type/protocol/sequencing/library_preparation_protocol.json#L73

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
After the change is promoted to integration by the metadata team we will need to: 
- Re-create both SS2 and 10x subscriptions and re-deploy Lira
- Create a new test bundle for SS2 and 10x using the integration test spreadsheet containing the renamed field 