### PR TITLE
Update subscribe.py

### DIFF
--- a/scripts/subscribe.py
+++ b/scripts/subscribe.py
@@ -133,7 +133,7 @@ def parser(arguments):
         sub_command.add_argument('--replica',
                                  help='Which replica to work on, use "gcp" by default. ["gcp", "aws"]',
                                  default='gcp')
-        sub_command.add_argument('--elasticsearch',
+        sub_command.add_argument('--subscription_type',
                                  help='Which type of subscription query you want to use, "elasticsearch" by default. ["elasticsearch", "jmespath"]',
                                  default='elasticsearch')
         sub_command.add_argument('--google_project',

--- a/scripts/subscribe.py
+++ b/scripts/subscribe.py
@@ -47,7 +47,7 @@ def create_subscription(args):
 
     response = requests.put(url=args['dss_url'],
                             json=payload,
-                            params={'replica': args['replica']},
+                            params={'replica': args['replica'], 'subscription_type': args['subscription_type']},
                             headers=headers)
     response.raise_for_status()
 
@@ -88,7 +88,7 @@ def get_subscriptions(args):
             args['dss_url']))
 
     response = requests.get(url=args['dss_url'],
-                            params={'replica': args['replica']},
+                            params={'replica': args['replica'], 'subscription_type': args['subscription_type']},
                             headers=args['headers'])
     response.raise_for_status()
     print(json.dumps(response.json(), indent=4))
@@ -103,7 +103,7 @@ def delete_subscription(args):
             url))
 
     response = requests.delete(url=url,
-                               params={'replica': args['replica']},
+                               params={'replica': args['replica'], 'subscription_type': args['subscription_type']},
                                headers=args['headers'])
     response.raise_for_status()
 
@@ -133,6 +133,9 @@ def parser(arguments):
         sub_command.add_argument('--replica',
                                  help='Which replica to work on, use "gcp" by default. ["gcp", "aws"]',
                                  default='gcp')
+        sub_command.add_argument('--elasticsearch',
+                                 help='Which type of subscription query you want to use, "elasticsearch" by default. ["elasticsearch", "jmespath"]',
+                                 default='elasticsearch')
         sub_command.add_argument('--google_project',
                                  help='The google project the Lira is using.',
                                  required=True)


### PR DESCRIPTION
### Purpose
_Please explain the purpose of this PR and include links to any GitHub issues that it fixes:_

- In response to https://github.com/HumanCellAtlas/data-store/pull/1915
---
### Changes
_Please list out what major changes were made in this PR to address the issue:_

- Update subscribe.py so it supports both `elasticsearch` and `jmespath` types of subscriptions.
---
### Review Instructions
_Please provide instructions about how should a reviewer test/verify the changes in this PR:_

- Please checkout the latest code, have a python3 env and run:
```bash
pip3 install -r requirements.txt

export dss_url="https://dss.staging.data.humancellatlas.org/v1/"
export key_file="path/to/the/bluebox-subscription-manager-key-staging.json"
export google_project="broad-dsde-mint-staging"
export replica="gcp"

python3 subscribe.py get --dss_url="$dss_url" \
                         --key_file="$key_file" \
                         --google_project="$google_project" \
                         --replica="$replica"
```
the `key_file` json file is stored in vault, you could find it by `vault list secret/dsde/mint/staging/lira`.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
