### PR TITLE
Remove `should` clauses from lira queries

### DIFF
--- a/subscription/elasticsearch_queries/smartseq2-query.json
+++ b/subscription/elasticsearch_queries/smartseq2-query.json
@@ -19,18 +19,6 @@
           }
         }
       ],
-      "should": [
-        {
-          "match": {
-            "files.dissociation_protocol_json.method.ontology": "EFO:0009108"
-          }
-        },
-        {
-          "match": {
-            "files.dissociation_protocol_json.method.text": "mouth pipette"
-          }
-        }
-      ],
       "must_not": [
         {
           "match": {


### PR DESCRIPTION
They don't do anything, they just look like they do. "If the bool query
is in a query context and has a must or filter clause then a document
will match the bool query even if none of the should queries match."

https://www.elastic.co/guide/en/elasticsearch/reference/6.3/query-dsl-bool-query.html