### PR TITLE
Label every workflow with a hash of its inputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 python:
   - '3.6'
 
+before_install:
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools
+
 install: "pip install -r requirements.txt"
 
 jobs:

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -64,7 +64,6 @@ def post(body):
     )  # Try to get the extra attachments field if it's applicable
 
     workflow_hash_label = bundle_inputs.create_workflow_inputs_hash_label(wdl_config.workflow_name,
-                                                                          wdl_config.workflow_version,
                                                                           uuid, version, lira_config.dss_url)
     cromwell_labels = lira_utils.compose_labels(
         wdl_config.workflow_name,

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -6,7 +6,7 @@ import cromwell_tools.cromwell_api
 import cromwell_tools.cromwell_auth
 import cromwell_tools.utilities
 from flask import current_app
-from lira import lira_utils
+from lira import lira_utils, bundle_inputs
 
 
 logger = logging.getLogger("{module_path}".format(module_path=__name__))
@@ -62,6 +62,10 @@ def post(body):
     attachments_from_notification = body.get(
         'attachments'
     )  # Try to get the extra attachments field if it's applicable
+
+    workflow_hash_label = bundle_inputs.create_workflow_inputs_hash_label(wdl_config.workflow_name,
+                                                                          wdl_config.workflow_version,
+                                                                          uuid, version, lira_config.dss_url)
     cromwell_labels = lira_utils.compose_labels(
         wdl_config.workflow_name,
         wdl_config.workflow_version,
@@ -69,7 +73,9 @@ def post(body):
         version,
         labels_from_notification,
         attachments_from_notification,
+        workflow_hash_label
     )
+
     cromwell_labels_file = json.dumps(cromwell_labels).encode('utf-8')
 
     logger.debug(f"Added labels {cromwell_labels_file} to workflow")

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -63,8 +63,9 @@ def post(body):
         'attachments'
     )  # Try to get the extra attachments field if it's applicable
 
-    workflow_hash_label = bundle_inputs.create_workflow_inputs_hash_label(wdl_config.workflow_name,
-                                                                          uuid, version, lira_config.dss_url)
+    workflow_hash_label = bundle_inputs.create_workflow_inputs_hash_label(
+        wdl_config.workflow_name, uuid, version, lira_config.dss_url
+    )
     cromwell_labels = lira_utils.compose_labels(
         wdl_config.workflow_name,
         wdl_config.workflow_version,
@@ -72,7 +73,7 @@ def post(body):
         version,
         labels_from_notification,
         attachments_from_notification,
-        workflow_hash_label
+        workflow_hash_label,
     )
 
     cromwell_labels_file = json.dumps(cromwell_labels).encode('utf-8')

--- a/lira/bundle_inputs.py
+++ b/lira/bundle_inputs.py
@@ -2,37 +2,64 @@ import hashlib
 from pipeline_tools.shared import metadata_utils, tenx_utils, http_requests
 
 
-def get_smartseq2_workflow_inputs(bundle):
+def get_hashes_from_file_manifest(file_manifest):
+    """ Return a string that is a concatenation of the file hashes provided in the bundle manifest entry for a file:
+        {sha1}{sha256}{s3_etag}{crc32c}
+    """
+    sha1 = file_manifest.sha1
+    sha256 = file_manifest.sha256
+    s3_etag = file_manifest.s3_etag
+    crc32c = file_manifest.crc32c
+    return '{sha1}{sha256}{s3_etag}{crc32c}'.format(sha1=sha1, sha256=sha256, s3_etag=s3_etag, crc32c=crc32c)
+
+
+def get_smartseq2_workflow_input_hash(bundle):
     """ Return a string that is a concatenation of bundle-specific Smartseq2 paired-end workflow inputs:
-        {sample_id}{taxon_id}{read_1_sha256}{read2_sha256}
+        {sample_id}{taxon_id}{read_1}{read2}
+
+        Where each "file hash" is a concatenation of {sha1}{sha256}{s3_etag}{crc32c}
     """
     sample_id = metadata_utils.get_sample_id(bundle)
     taxon_id = metadata_utils.get_sample_id(bundle)
-    read_1_sha = [sf.manifest_entry.sha256 for sf in bundle.sequencing_output if sf.read_index == 'read1']
-    read_2_sha = [sf.manifest_entry.sha256 for sf in bundle.sequencing_output if sf.read_index == 'read2']
+    r1_manifest = [sf.manifest_entry for sf in bundle.sequencing_output if sf.read_index == 'read1']
+    r2_manifest = [sf.manifest_entry for sf in bundle.sequencing_output if sf.read_index == 'read2']
+    r1_hashes = get_hashes_from_file_manifest(r1_manifest[0])
+    r2_hashes = get_hashes_from_file_manifest(r2_manifest[0])
     return bytes('{sample_id}{taxon_id}{read_1}{read_2}'.format(sample_id=sample_id,
                                                                 taxon_id=taxon_id,
-                                                                read_1=read_1_sha[0],
-                                                                read_2=read_2_sha[0]), encoding='utf8')
+                                                                read_1=r1_hashes,
+                                                                read_2=r2_hashes), encoding='utf8')
 
 
-def get_optimus_workflow_inputs(bundle):
+def get_optimus_workflow_input_hash(bundle):
+    """ Return a string that is a concatenation of bundle-specific Optimus workflow inputs
+    where the file hashes are for each set of read_1, read_2 and index_1 files in the order
+    of their flow cell lane number. For example:
+    {sample_id}{taxon_id}{lane1_r1}{lane1_r2}{lane1_i1}{lane2_r1}{lane2_r2}{lane2_i1}
+
+    Each "file hash" is a concatenation of {sha1}{sha256}{s3_etag}{crc32c}
+    """
     sample_id = metadata_utils.get_sample_id(bundle)
     taxon_id = metadata_utils.get_sample_id(bundle)
     inputs = '{sample_id}{taxon_id}'.format(sample_id=sample_id, taxon_id=taxon_id)
     fastq_files = [f for f in bundle.files.values() if str(f.format).lower() in ('fastq.gz', 'fastq')]
     fastq_dict = tenx_utils.create_fastq_dict(fastq_files)
-    for lane in fastq_dict:
-        file_hashes = '{0}{1}'.format(fastq_dict[lane]['read1']['sha256'], fastq_dict[lane]['read2']['sha256'])
+    sorted_lanes = sorted(fastq_dict.keys(), key=int)
+    for lane in sorted_lanes:
+        r1_hashes = get_hashes_from_file_manifest(fastq_dict[lane]['read1'])
+        r2_hashes = get_hashes_from_file_manifest(fastq_dict[lane]['read2'])
+        file_hashes = '{0}{1}'.format(r1_hashes, r2_hashes)
         if fastq_dict[lane].get('index1'):
-            file_hashes += fastq_dict[lane]['index1']['sha256']
+            i1_hashes = get_hashes_from_file_manifest(fastq_dict[lane]['index1'])
+            file_hashes += i1_hashes
         inputs += file_hashes
-    return bytes(inputs)
+    return bytes(inputs, encoding='utf8')
 
 
-# what if inputs change in a newer version?
-WORKFLOW_INPUTS = {'AdapterSmartSeq2SingleCell': get_smartseq2_workflow_inputs,
-                   'AdapterOptimus': get_optimus_workflow_inputs}
+WORKFLOW_INPUTS = {
+    'AdapterSmartSeq2SingleCell': get_smartseq2_workflow_input_hash,
+    'AdapterOptimus': get_optimus_workflow_input_hash
+}
 
 
 def create_workflow_inputs_hash_label(workflow_name, bundle_id, bundle_version, dss_url):
@@ -41,4 +68,4 @@ def create_workflow_inputs_hash_label(workflow_name, bundle_id, bundle_version, 
         bundle = metadata_utils.get_bundle_metadata(bundle_id, bundle_version, dss_url, http_requests.HttpRequests())
         workflow_inputs = get_inputs_fn(bundle)
         sha256_hash = hashlib.sha256(workflow_inputs)
-        return {'workflow-hash': sha256_hash.hexdigest()}
+        return {'hash-id': sha256_hash.hexdigest()}

--- a/lira/bundle_inputs.py
+++ b/lira/bundle_inputs.py
@@ -4,11 +4,13 @@ from pipeline_tools.pipelines.optimus import optimus
 
 WORKFLOW_INPUTS = {
     'AdapterSmartSeq2SingleCell': smartseq2.get_ss2_paired_end_inputs_to_hash,
-    'AdapterOptimus': optimus.get_optimus_inputs_to_hash
+    'AdapterOptimus': optimus.get_optimus_inputs_to_hash,
 }
 
 
-def create_workflow_inputs_hash_label(workflow_name, bundle_id, bundle_version, dss_url):
+def create_workflow_inputs_hash_label(
+    workflow_name, bundle_id, bundle_version, dss_url
+):
     """
     Create a hash out of the bundle-specific inputs for a workflow.
     """

--- a/lira/bundle_inputs.py
+++ b/lira/bundle_inputs.py
@@ -35,11 +35,10 @@ WORKFLOW_INPUTS = {'AdapterSmartSeq2SingleCell': get_smartseq2_workflow_inputs,
                    'AdapterOptimus': get_optimus_workflow_inputs}
 
 
-def create_workflow_inputs_hash_label(workflow_name, workflow_version, bundle_id, bundle_version, dss_url):
+def create_workflow_inputs_hash_label(workflow_name, bundle_id, bundle_version, dss_url):
     get_inputs_fn = WORKFLOW_INPUTS.get(workflow_name, None)
     if get_inputs_fn:
         bundle = metadata_utils.get_bundle_metadata(bundle_id, bundle_version, dss_url, http_requests.HttpRequests())
         workflow_inputs = get_inputs_fn(bundle)
         sha256_hash = hashlib.sha256(workflow_inputs)
-        sha256_hash.update(bytes(workflow_version, encoding='utf8'))
         return {'workflow-hash': sha256_hash.hexdigest()}

--- a/lira/bundle_inputs.py
+++ b/lira/bundle_inputs.py
@@ -12,11 +12,8 @@ def create_workflow_inputs_hash_label(workflow_name, bundle_id, bundle_version, 
     """
     Create a hash out of the bundle-specific inputs for a workflow.
     """
-    get_inputs_fn = WORKFLOW_INPUTS.get(workflow_name, None)
-    if get_inputs_fn:
-        workflow_inputs = get_inputs_fn(bundle_id, bundle_version, dss_url)
-        formatted_inputs = ''
-        for i in workflow_inputs:
-            formatted_inputs += i
-        sha256_hash = hashlib.sha256(bytes(formatted_inputs, encoding='utf-8'))
+    get_inputs_to_hash = WORKFLOW_INPUTS.get(workflow_name, None)
+    if get_inputs_to_hash:
+        workflow_inputs = get_inputs_to_hash(bundle_id, bundle_version, dss_url)
+        sha256_hash = hashlib.sha256(bytes(''.join(workflow_inputs), encoding='utf-8'))
         return {'hash-id': sha256_hash.hexdigest()}

--- a/lira/bundle_inputs.py
+++ b/lira/bundle_inputs.py
@@ -1,8 +1,5 @@
-import logging
 import hashlib
 from pipeline_tools.shared import metadata_utils, tenx_utils, http_requests
-
-logger = logging.getLogger("{module_path}".format(module_path=__name__))
 
 
 def get_smartseq2_workflow_inputs(bundle):
@@ -43,8 +40,6 @@ def create_workflow_inputs_hash_label(workflow_name, workflow_version, bundle_id
     if get_inputs_fn:
         bundle = metadata_utils.get_bundle_metadata(bundle_id, bundle_version, dss_url, http_requests.HttpRequests())
         workflow_inputs = get_inputs_fn(bundle)
-        logger.error(workflow_inputs)
-        logger.error(hashlib.sha256(workflow_inputs))
-        sha256_hash = hashlib.sha256(workflow_inputs).update(bytes(workflow_version, encoding='utf8'))
-        logger.error(sha256_hash)
+        sha256_hash = hashlib.sha256(workflow_inputs)
+        sha256_hash.update(bytes(workflow_version, encoding='utf8'))
         return {'workflow-hash': sha256_hash.hexdigest()}

--- a/lira/bundle_inputs.py
+++ b/lira/bundle_inputs.py
@@ -1,5 +1,8 @@
+import logging
 import hashlib
 from pipeline_tools.shared import metadata_utils, tenx_utils, http_requests
+
+logger = logging.getLogger("{module_path}".format(module_path=__name__))
 
 
 def get_smartseq2_workflow_inputs(bundle):
@@ -13,7 +16,7 @@ def get_smartseq2_workflow_inputs(bundle):
     return bytes('{sample_id}{taxon_id}{read_1}{read_2}'.format(sample_id=sample_id,
                                                                 taxon_id=taxon_id,
                                                                 read_1=read_1_sha[0],
-                                                                read_2=read_2_sha[0]))
+                                                                read_2=read_2_sha[0]), encoding='utf8')
 
 
 def get_optimus_workflow_inputs(bundle):
@@ -40,5 +43,8 @@ def create_workflow_inputs_hash_label(workflow_name, workflow_version, bundle_id
     if get_inputs_fn:
         bundle = metadata_utils.get_bundle_metadata(bundle_id, bundle_version, dss_url, http_requests.HttpRequests())
         workflow_inputs = get_inputs_fn(bundle)
-        sha256_hash = hashlib.sha256(workflow_inputs).update(bytes(workflow_version))
+        logger.error(workflow_inputs)
+        logger.error(hashlib.sha256(workflow_inputs))
+        sha256_hash = hashlib.sha256(workflow_inputs).update(bytes(workflow_version, encoding='utf8'))
+        logger.error(sha256_hash)
         return {'workflow-hash': sha256_hash.hexdigest()}

--- a/lira/bundle_inputs.py
+++ b/lira/bundle_inputs.py
@@ -1,71 +1,22 @@
 import hashlib
-from pipeline_tools.shared import metadata_utils, tenx_utils, http_requests
-
-
-def get_hashes_from_file_manifest(file_manifest):
-    """ Return a string that is a concatenation of the file hashes provided in the bundle manifest entry for a file:
-        {sha1}{sha256}{s3_etag}{crc32c}
-    """
-    sha1 = file_manifest.sha1
-    sha256 = file_manifest.sha256
-    s3_etag = file_manifest.s3_etag
-    crc32c = file_manifest.crc32c
-    return '{sha1}{sha256}{s3_etag}{crc32c}'.format(sha1=sha1, sha256=sha256, s3_etag=s3_etag, crc32c=crc32c)
-
-
-def get_smartseq2_workflow_input_hash(bundle):
-    """ Return a string that is a concatenation of bundle-specific Smartseq2 paired-end workflow inputs:
-        {sample_id}{taxon_id}{read_1}{read2}
-
-        Where each "file hash" is a concatenation of {sha1}{sha256}{s3_etag}{crc32c}
-    """
-    sample_id = metadata_utils.get_sample_id(bundle)
-    taxon_id = metadata_utils.get_sample_id(bundle)
-    r1_manifest = [sf.manifest_entry for sf in bundle.sequencing_output if sf.read_index == 'read1']
-    r2_manifest = [sf.manifest_entry for sf in bundle.sequencing_output if sf.read_index == 'read2']
-    r1_hashes = get_hashes_from_file_manifest(r1_manifest[0])
-    r2_hashes = get_hashes_from_file_manifest(r2_manifest[0])
-    return bytes('{sample_id}{taxon_id}{read_1}{read_2}'.format(sample_id=sample_id,
-                                                                taxon_id=taxon_id,
-                                                                read_1=r1_hashes,
-                                                                read_2=r2_hashes), encoding='utf8')
-
-
-def get_optimus_workflow_input_hash(bundle):
-    """ Return a string that is a concatenation of bundle-specific Optimus workflow inputs
-    where the file hashes are for each set of read_1, read_2 and index_1 files in the order
-    of their flow cell lane number. For example:
-    {sample_id}{taxon_id}{lane1_r1}{lane1_r2}{lane1_i1}{lane2_r1}{lane2_r2}{lane2_i1}
-
-    Each "file hash" is a concatenation of {sha1}{sha256}{s3_etag}{crc32c}
-    """
-    sample_id = metadata_utils.get_sample_id(bundle)
-    taxon_id = metadata_utils.get_sample_id(bundle)
-    inputs = '{sample_id}{taxon_id}'.format(sample_id=sample_id, taxon_id=taxon_id)
-    fastq_files = [f for f in bundle.files.values() if str(f.format).lower() in ('fastq.gz', 'fastq')]
-    fastq_dict = tenx_utils.create_fastq_dict(fastq_files)
-    sorted_lanes = sorted(fastq_dict.keys(), key=int)
-    for lane in sorted_lanes:
-        r1_hashes = get_hashes_from_file_manifest(fastq_dict[lane]['read1'])
-        r2_hashes = get_hashes_from_file_manifest(fastq_dict[lane]['read2'])
-        file_hashes = '{0}{1}'.format(r1_hashes, r2_hashes)
-        if fastq_dict[lane].get('index1'):
-            i1_hashes = get_hashes_from_file_manifest(fastq_dict[lane]['index1'])
-            file_hashes += i1_hashes
-        inputs += file_hashes
-    return bytes(inputs, encoding='utf8')
-
+from pipeline_tools.pipelines.smartseq2 import smartseq2
+from pipeline_tools.pipelines.optimus import optimus
 
 WORKFLOW_INPUTS = {
-    'AdapterSmartSeq2SingleCell': get_smartseq2_workflow_input_hash,
-    'AdapterOptimus': get_optimus_workflow_input_hash
+    'AdapterSmartSeq2SingleCell': smartseq2.get_ss2_paired_end_inputs_to_hash,
+    'AdapterOptimus': optimus.get_optimus_inputs_to_hash
 }
 
 
 def create_workflow_inputs_hash_label(workflow_name, bundle_id, bundle_version, dss_url):
+    """
+    Create a hash out of the bundle-specific inputs for a workflow.
+    """
     get_inputs_fn = WORKFLOW_INPUTS.get(workflow_name, None)
     if get_inputs_fn:
-        bundle = metadata_utils.get_bundle_metadata(bundle_id, bundle_version, dss_url, http_requests.HttpRequests())
-        workflow_inputs = get_inputs_fn(bundle)
-        sha256_hash = hashlib.sha256(workflow_inputs)
+        workflow_inputs = get_inputs_fn(bundle_id, bundle_version, dss_url)
+        formatted_inputs = ''
+        for i in workflow_inputs:
+            formatted_inputs += i
+        sha256_hash = hashlib.sha256(bytes(formatted_inputs, encoding='utf-8'))
         return {'hash-id': sha256_hash.hexdigest()}

--- a/lira/bundle_inputs.py
+++ b/lira/bundle_inputs.py
@@ -1,0 +1,44 @@
+import hashlib
+from pipeline_tools.shared import metadata_utils, tenx_utils, http_requests
+
+
+def get_smartseq2_workflow_inputs(bundle):
+    """ Return a string that is a concatenation of bundle-specific Smartseq2 paired-end workflow inputs:
+        {sample_id}{taxon_id}{read_1_sha256}{read2_sha256}
+    """
+    sample_id = metadata_utils.get_sample_id(bundle)
+    taxon_id = metadata_utils.get_sample_id(bundle)
+    read_1_sha = [sf.manifest_entry.sha256 for sf in bundle.sequencing_output if sf.read_index == 'read1']
+    read_2_sha = [sf.manifest_entry.sha256 for sf in bundle.sequencing_output if sf.read_index == 'read2']
+    return bytes('{sample_id}{taxon_id}{read_1}{read_2}'.format(sample_id=sample_id,
+                                                                taxon_id=taxon_id,
+                                                                read_1=read_1_sha[0],
+                                                                read_2=read_2_sha[0]))
+
+
+def get_optimus_workflow_inputs(bundle):
+    sample_id = metadata_utils.get_sample_id(bundle)
+    taxon_id = metadata_utils.get_sample_id(bundle)
+    inputs = '{sample_id}{taxon_id}'.format(sample_id=sample_id, taxon_id=taxon_id)
+    fastq_files = [f for f in bundle.files.values() if str(f.format).lower() in ('fastq.gz', 'fastq')]
+    fastq_dict = tenx_utils.create_fastq_dict(fastq_files)
+    for lane in fastq_dict:
+        file_hashes = '{0}{1}'.format(fastq_dict[lane]['read1']['sha256'], fastq_dict[lane]['read2']['sha256'])
+        if fastq_dict[lane].get('index1'):
+            file_hashes += fastq_dict[lane]['index1']['sha256']
+        inputs += file_hashes
+    return bytes(inputs)
+
+
+# what if inputs change in a newer version?
+WORKFLOW_INPUTS = {'AdapterSmartSeq2SingleCell': get_smartseq2_workflow_inputs,
+                   'AdapterOptimus': get_optimus_workflow_inputs}
+
+
+def create_workflow_inputs_hash_label(workflow_name, workflow_version, bundle_id, bundle_version, dss_url):
+    get_inputs_fn = WORKFLOW_INPUTS.get(workflow_name, None)
+    if get_inputs_fn:
+        bundle = metadata_utils.get_bundle_metadata(bundle_id, bundle_version, dss_url, http_requests.HttpRequests())
+        workflow_inputs = get_inputs_fn(bundle)
+        sha256_hash = hashlib.sha256(workflow_inputs).update(bytes(workflow_version))
+        return {'workflow-hash': sha256_hash.hexdigest()}

--- a/lira/bundle_inputs.py
+++ b/lira/bundle_inputs.py
@@ -17,5 +17,8 @@ def create_workflow_inputs_hash_label(
     get_inputs_to_hash = WORKFLOW_INPUTS.get(workflow_name, None)
     if get_inputs_to_hash:
         workflow_inputs = get_inputs_to_hash(bundle_id, bundle_version, dss_url)
-        sha256_hash = hashlib.sha256(bytes(''.join(workflow_inputs), encoding='utf-8'))
+
+        sha256_hash = hashlib.sha256(
+            bytes(''.join((str(i) for i in workflow_inputs)), encoding='utf-8')
+        )
         return {'hash-id': sha256_hash.hexdigest()}

--- a/lira/test/test_bundle_inputs.py
+++ b/lira/test/test_bundle_inputs.py
@@ -1,0 +1,50 @@
+import hashlib
+import unittest
+from unittest import mock
+from lira import bundle_inputs
+from pipeline_tools.shared.metadata_utils import get_hashes_from_file_manifest
+from humancellatlas.data.metadata.api import ManifestEntry
+
+
+class TestGetBundleInputs(unittest.TestCase):
+
+    def setUp(self):
+        self.workflow_name = 'AdapterSmartSeq2SingleCell'
+        self.sample_id = 'sample_id'
+        self.taxon_id = 'taxon_id'
+        self.fastq1_manifest = ManifestEntry(url='gs://foo/read1.fastq',
+                                             sha1='sha1_read1',
+                                             sha256='sha256_read1',
+                                             s3_etag='s3_etag_read1',
+                                             crc32c='crc32c_read1',
+                                             uuid='1',
+                                             version='v1',
+                                             size='100',
+                                             name='read1.fastq',
+                                             indexed=True,
+                                             content_type='fastq')
+        self.fastq2_manifest = ManifestEntry(url='gs://foo/read2.fastq',
+                                             sha1='sha1_read2',
+                                             sha256='sha256_read2',
+                                             s3_etag='s3_etag_read2',
+                                             crc32c='crc32c_read2',
+                                             uuid='2',
+                                             version='v1',
+                                             size='100',
+                                             name='read2.fastq',
+                                             indexed=True,
+                                             content_type='fastq')
+
+    @mock.patch('pipeline_tools.pipelines.smartseq2.smartseq2.get_ss2_paired_end_inputs')
+    def test_create_workflow_inputs_hash_label(self, mock_hash):
+        expected_inputs = (self.sample_id, self.taxon_id, self.fastq1_manifest, self.fastq2_manifest)
+        mock_hash.return_value = expected_inputs
+        workflow_hash = bundle_inputs.create_workflow_inputs_hash_label(workflow_name=self.workflow_name,
+                                                                        bundle_id='fake_id',
+                                                                        bundle_version='fake_version',
+                                                                        dss_url='https://fake-url.org')
+        r1_file_hashes = get_hashes_from_file_manifest(self.fastq1_manifest)
+        r2_file_hashes = get_hashes_from_file_manifest(self.fastq2_manifest)
+        expected_hash = hashlib.sha256(bytes(f'{self.sample_id}{self.taxon_id}{r1_file_hashes}{r2_file_hashes}',
+                                             encoding='utf-8'))
+        self.assertEquals(workflow_hash['hash-id'], expected_hash.hexdigest())

--- a/lira/test/test_bundle_inputs.py
+++ b/lira/test/test_bundle_inputs.py
@@ -7,44 +7,60 @@ from humancellatlas.data.metadata.api import ManifestEntry
 
 
 class TestGetBundleInputs(unittest.TestCase):
-
     def setUp(self):
         self.workflow_name = 'AdapterSmartSeq2SingleCell'
         self.sample_id = 'sample_id'
         self.taxon_id = 'taxon_id'
-        self.fastq1_manifest = ManifestEntry(url='gs://foo/read1.fastq',
-                                             sha1='sha1_read1',
-                                             sha256='sha256_read1',
-                                             s3_etag='s3_etag_read1',
-                                             crc32c='crc32c_read1',
-                                             uuid='1',
-                                             version='v1',
-                                             size='100',
-                                             name='read1.fastq',
-                                             indexed=True,
-                                             content_type='fastq')
-        self.fastq2_manifest = ManifestEntry(url='gs://foo/read2.fastq',
-                                             sha1='sha1_read2',
-                                             sha256='sha256_read2',
-                                             s3_etag='s3_etag_read2',
-                                             crc32c='crc32c_read2',
-                                             uuid='2',
-                                             version='v1',
-                                             size='100',
-                                             name='read2.fastq',
-                                             indexed=True,
-                                             content_type='fastq')
+        self.fastq1_manifest = ManifestEntry(
+            url='gs://foo/read1.fastq',
+            sha1='sha1_read1',
+            sha256='sha256_read1',
+            s3_etag='s3_etag_read1',
+            crc32c='crc32c_read1',
+            uuid='1',
+            version='v1',
+            size='100',
+            name='read1.fastq',
+            indexed=True,
+            content_type='fastq',
+        )
+        self.fastq2_manifest = ManifestEntry(
+            url='gs://foo/read2.fastq',
+            sha1='sha1_read2',
+            sha256='sha256_read2',
+            s3_etag='s3_etag_read2',
+            crc32c='crc32c_read2',
+            uuid='2',
+            version='v1',
+            size='100',
+            name='read2.fastq',
+            indexed=True,
+            content_type='fastq',
+        )
 
-    @mock.patch('pipeline_tools.pipelines.smartseq2.smartseq2.get_ss2_paired_end_inputs')
+    @mock.patch(
+        'pipeline_tools.pipelines.smartseq2.smartseq2.get_ss2_paired_end_inputs'
+    )
     def test_create_workflow_inputs_hash_label(self, mock_hash):
-        expected_inputs = (self.sample_id, self.taxon_id, self.fastq1_manifest, self.fastq2_manifest)
+        expected_inputs = (
+            self.sample_id,
+            self.taxon_id,
+            self.fastq1_manifest,
+            self.fastq2_manifest,
+        )
         mock_hash.return_value = expected_inputs
-        workflow_hash = bundle_inputs.create_workflow_inputs_hash_label(workflow_name=self.workflow_name,
-                                                                        bundle_id='fake_id',
-                                                                        bundle_version='fake_version',
-                                                                        dss_url='https://fake-url.org')
+        workflow_hash = bundle_inputs.create_workflow_inputs_hash_label(
+            workflow_name=self.workflow_name,
+            bundle_id='fake_id',
+            bundle_version='fake_version',
+            dss_url='https://fake-url.org',
+        )
         r1_file_hashes = get_hashes_from_file_manifest(self.fastq1_manifest)
         r2_file_hashes = get_hashes_from_file_manifest(self.fastq2_manifest)
-        expected_hash = hashlib.sha256(bytes(f'{self.sample_id}{self.taxon_id}{r1_file_hashes}{r2_file_hashes}',
-                                             encoding='utf-8'))
+        expected_hash = hashlib.sha256(
+            bytes(
+                f'{self.sample_id}{self.taxon_id}{r1_file_hashes}{r2_file_hashes}',
+                encoding='utf-8',
+            )
+        )
         self.assertEquals(workflow_hash['hash-id'], expected_hash.hexdigest())

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ cromwell-tools>=1.1.1, <2
 black==19.3b0
 flake8==3.7.7
 pre-commit==1.14.4
+git+git://github.com/HumanCellAtlas/pipeline-tools@4f182eeb2c84ab690d3d391d1c56dc1cdcfca357

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ cromwell-tools>=1.1.1, <2
 black==19.3b0
 flake8==3.7.7
 pre-commit==1.14.4
-git+git://github.com/HumanCellAtlas/pipeline-tools@4f182eeb2c84ab690d3d391d1c56dc1cdcfca357
+git+git://github.com/HumanCellAtlas/pipeline-tools@970b57c2c8d3a419a381018c2beb41bedbaa27b4

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ cromwell-tools>=1.1.1, <2
 black==19.3b0
 flake8==3.7.7
 pre-commit==1.14.4
-git+git://github.com/HumanCellAtlas/pipeline-tools@70c859b2c90ec95c98dcd15d679a1f2fe99b30be
+git+git://github.com/HumanCellAtlas/pipeline-tools@v0.55.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 wheel==0.32.3
 connexion[swagger-ui]==2.2.0
-google-auth==1.5.0
-google-cloud-storage==1.9.0
 flask>=1.0.0
 gunicorn==19.9.0
 gevent==1.4.0
@@ -14,4 +12,4 @@ cromwell-tools>=1.1.1, <2
 black==19.3b0
 flake8==3.7.7
 pre-commit==1.14.4
-git+git://github.com/HumanCellAtlas/pipeline-tools@1e647874f693ffba0091b8054fe99b4e725a570e
+git+git://github.com/HumanCellAtlas/pipeline-tools@f32405347234322ff236486e8f93fbfb015a4fca

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ cromwell-tools>=1.1.1, <2
 black==19.3b0
 flake8==3.7.7
 pre-commit==1.14.4
-git+git://github.com/HumanCellAtlas/pipeline-tools@970b57c2c8d3a419a381018c2beb41bedbaa27b4
+git+git://github.com/HumanCellAtlas/pipeline-tools@1e647874f693ffba0091b8054fe99b4e725a570e

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flask>=1.0.0
 gunicorn==19.9.0
 gevent==1.4.0
 requests==2.20.0
-requests-mock==1.5.0
+requests-mock>=1.5.2, <2
 oauth2client==4.1.2
 mock==2.0.0
 requests-http-signature==v0.0.3
@@ -12,4 +12,4 @@ cromwell-tools>=1.1.1, <2
 black==19.3b0
 flake8==3.7.7
 pre-commit==1.14.4
-git+git://github.com/HumanCellAtlas/pipeline-tools@f32405347234322ff236486e8f93fbfb015a4fca
+git+git://github.com/HumanCellAtlas/pipeline-tools@70c859b2c90ec95c98dcd15d679a1f2fe99b30be


### PR DESCRIPTION
### Purpose
Label every workflow with a hash of its inputs so that it is possible to check if a workflow has already been run on that data.

### Changes
Label SS2 and Optimus workflows with a hash of the sample_id, taxon_id, and fastq file hashes. For each fastq file, concatenate the sha1, sha256, s3-etag and crc32c hashes provided by the data store. 

Note: Because the default digest size is 32, and the hexdigest is twice as long, each label will always be 64 characters long (which is below Cromwell's cut-off limit of 255 characters) 

### Review Instructions
Confirm that two workflows run on the exact same bundle produce the same label hash by checking the "labels" tab in job manager and looking for "hash-id".

Example for SmartSeq2:
1) https://job-manager.caas-prod.broadinstitute.org/jobs/e466e536-9cf3-4089-a870-76c0b4aca72e
2) https://job-manager.caas-prod.broadinstitute.org/jobs/4e319415-e9ae-4216-993d-2f9395204064