### PR TITLE
use max_cromwell_retries config field to set cromwell options

### DIFF
--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -104,6 +104,7 @@ def post(body):
                 username=lira_config.cromwell_user,
                 password=lira_config.cromwell_password,
             )
+        options_file = lira_utils.compose_config_options(options_file, lira_config)
 
         cromwell_response = cromwell_tools.cromwell_api.CromwellAPI.submit(
             auth=auth,

--- a/lira/lira_config.py
+++ b/lira/lira_config.py
@@ -245,7 +245,7 @@ class LiraConfig(Config):
         )
 
         config_object['max_cromwell_retries'] = config_object.get(
-            'max_cromwell_retries', 0
+            'max_cromwell_retries', 1
         )
 
         Config.__init__(self, config_object, *args, **kwargs)

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -227,7 +227,9 @@ def compose_config_options(cromwell_options_file, lira_config):
     # Docs on default runtime attributes: https://cromwell.readthedocs.io/en/latest/wf_options/Overview/
     runtime_parameters = options_json.get('default_runtime_attributes', {})
     if 'maxRetries' not in runtime_parameters.keys():
-        options_json['default_runtime_attributes'] = {'maxRetries': lira_config.max_cromwell_retries}
+        options_json['default_runtime_attributes'] = {
+            'maxRetries': lira_config.max_cromwell_retries
+        }
 
     return json.dumps(options_json).encode('utf-8')
 

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -223,9 +223,11 @@ def compose_config_options(cromwell_options_file, lira_config):
         cromwell_options_file = cromwell_options_file.decode()
     options_json = json.loads(cromwell_options_file)
 
-    # defer to value already in options file if it exists
-    if 'maxRetries' not in options_json.keys():
-        options_json['maxRetries'] = lira_config.max_cromwell_retries
+    # Defer to value already in options file if it exists
+    # Docs on default runtime attributes: https://cromwell.readthedocs.io/en/latest/wf_options/Overview/
+    runtime_parameters = options_json.get('default_runtime_attributes', {})
+    if 'maxRetries' not in runtime_parameters.keys():
+        options_json['default_runtime_attributes'] = {'maxRetries': lira_config.max_cromwell_retries}
 
     return json.dumps(options_json).encode('utf-8')
 

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -181,7 +181,6 @@ def compose_inputs(workflow_name, uuid, version, lira_config):
         workflow_name + '.dss_url': lira_config.dss_url,
         workflow_name + '.submit_url': lira_config.ingest_url,
         workflow_name + '.schema_url': lira_config.schema_url,
-        workflow_name + '.max_cromwell_retries': lira_config.max_cromwell_retries,
         workflow_name + '.cromwell_url': lira_config.cromwell_url,
     }
 
@@ -217,6 +216,18 @@ def compose_caas_options(cromwell_options_file, lira_config):
         }
     )
     return options_json
+
+
+def compose_config_options(cromwell_options_file, lira_config):
+    if isinstance(cromwell_options_file, bytes):
+        cromwell_options_file = cromwell_options_file.decode()
+    options_json = json.loads(cromwell_options_file)
+
+    # defer to value already in options file if it exists
+    if 'maxRetries' not in options_json.keys():
+        options_json['maxRetries'] = lira_config.max_cromwell_retries
+
+    return json.dumps(options_json).encode('utf-8')
 
 
 def parse_github_resource_url(url):

--- a/lira/test/data/options_with_runtime_params.json
+++ b/lira/test/data/options_with_runtime_params.json
@@ -1,0 +1,7 @@
+{
+  "monitoring_script": "gs://hca-dcp-mint-test-data/accessories/monitoring/smartseq2/monitor.sh",
+  "read_from_cache": true,
+  "default_runtime_attributes": {
+    "maxRetries": 3
+  }
+}

--- a/lira/test/test_config.py
+++ b/lira/test/test_config.py
@@ -211,10 +211,10 @@ class TestStartupVerification(unittest.TestCase):
         config = lira_config.LiraConfig(test_config)
         self.assertEqual(config.collection_name, 'fake-collection-name')
 
-    def test_max_cromwell_retries_defaults_to_zero(self):
+    def test_max_cromwell_retries_defaults_to_one(self):
         test_config = deepcopy(self.correct_test_config)
         config = lira_config.LiraConfig(test_config)
-        self.assertEqual(config.max_cromwell_retries, 0)
+        self.assertEqual(config.max_cromwell_retries, 1)
 
     def test_max_cromwell_retries_can_be_set(self):
         test_config = deepcopy(self.correct_test_config)

--- a/lira/test/test_get_version.py
+++ b/lira/test/test_get_version.py
@@ -71,7 +71,7 @@ class TestGetVersion(unittest.TestCase):
             'https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1',
         )
         self.assertEqual(
-            json_response.get('settings_info').get('max_cromwell_retries'), 0
+            json_response.get('settings_info').get('max_cromwell_retries'), 1
         )
         self.assertEqual(
             json.dumps(json_response.get('settings_info').get('use_caas')), 'false'

--- a/lira/test/test_lira_utils.py
+++ b/lira/test/test_lira_utils.py
@@ -449,6 +449,13 @@ class TestUtils(unittest.TestCase):
             fake_caas_key_json['client_email'],
         )
 
+    def test_compose_config_options(self):
+        test_config = deepcopy(self.correct_test_config)
+        config = lira_config.LiraConfig(test_config)
+        self.assertNotIn('maxRetries', json.loads(self.options_json))
+        options = lira_utils.compose_config_options(self.options_json, config)
+        self.assertEqual(json.loads(options)['maxRetries'], 1)
+
     def test_parse_github_resource_url(self):
         """Test if parse_github_resource_url can correctly parse Github resource urls."""
         self.assertEqual(

--- a/lira/test/test_lira_utils.py
+++ b/lira/test/test_lira_utils.py
@@ -76,6 +76,8 @@ class TestUtils(unittest.TestCase):
             cls.correct_test_config = json.load(f)
         with open('data/options.json') as f:
             cls.options_json = f.read()
+        with open('data/options_with_runtime_params.json') as f:
+            cls.options_with_runtime_json = f.read()
 
     def test_is_authenticated_query_param_no_auth_header(self):
         """Request without 'auth' key in header should not be treated as authenticated.
@@ -449,12 +451,25 @@ class TestUtils(unittest.TestCase):
             fake_caas_key_json['client_email'],
         )
 
-    def test_compose_config_options(self):
+    def test_max_retries_uses_value_set_in_options_file(self):
         test_config = deepcopy(self.correct_test_config)
         config = lira_config.LiraConfig(test_config)
-        self.assertNotIn('maxRetries', json.loads(self.options_json))
+        options_from_file = json.loads(self.options_with_runtime_json)
+        expected_max_retries = options_from_file['default_runtime_attributes']['maxRetries']
+        options = lira_utils.compose_config_options(self.options_with_runtime_json, config)
+        max_retries = json.loads(options)['default_runtime_attributes']['maxRetries']
+        self.assertEqual(max_retries, expected_max_retries)
+
+    def test_max_retries_uses_value_from_lira_config_if_not_set_in_options(self):
+        test_config = deepcopy(self.correct_test_config)
+        config = lira_config.LiraConfig(test_config)
+        expected_max_retries = config.get('max_cromwell_retries')
+        options_from_file = json.loads(self.options_json)
+        runtime_parameters = options_from_file.get('default_runtime_attributes', {})
+        self.assertIsNone(runtime_parameters.get('maxRetries'))
         options = lira_utils.compose_config_options(self.options_json, config)
-        self.assertEqual(json.loads(options)['maxRetries'], 1)
+        max_retries = json.loads(options)['default_runtime_attributes']['maxRetries']
+        self.assertEqual(max_retries, expected_max_retries)
 
     def test_parse_github_resource_url(self):
         """Test if parse_github_resource_url can correctly parse Github resource urls."""

--- a/lira/test/test_lira_utils.py
+++ b/lira/test/test_lira_utils.py
@@ -455,8 +455,12 @@ class TestUtils(unittest.TestCase):
         test_config = deepcopy(self.correct_test_config)
         config = lira_config.LiraConfig(test_config)
         options_from_file = json.loads(self.options_with_runtime_json)
-        expected_max_retries = options_from_file['default_runtime_attributes']['maxRetries']
-        options = lira_utils.compose_config_options(self.options_with_runtime_json, config)
+        expected_max_retries = options_from_file['default_runtime_attributes'][
+            'maxRetries'
+        ]
+        options = lira_utils.compose_config_options(
+            self.options_with_runtime_json, config
+        )
         max_retries = json.loads(options)['default_runtime_attributes']['maxRetries']
         self.assertEqual(max_retries, expected_max_retries)
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->

[JIRA](https://broadinstitute.atlassian.net/browse/GH-282)

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

use max_cromwell_retries config field to set cromwell options for workflows
[parallel workflow changes in skylab](https://github.com/HumanCellAtlas/skylab/pull/226)
[parallel workflow changes in pipeline-tools](https://github.com/HumanCellAtlas/pipeline-tools/pull/151)

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
