### PR TITLE
Add query for only test data

### DIFF
--- a/subscription/elasticsearch_queries/prod-test-data.json
+++ b/subscription/elasticsearch_queries/prod-test-data.json
@@ -1,0 +1,20 @@
+{
+  "query": {
+    "bool": {
+      "should": [
+        {
+          "prefix": {
+            "files.project_json.project_core.project_short_name": "prod"
+          }
+        }
+      ],
+      "must_not": [
+        {
+          "match": {
+            "files.analysis_process_json.type.text": "analysis"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Purpose
This subscription query can be used in production to enable notifications for only integration test data. This will allow data wranglers to update primary submissions without triggering analysis workflows.

### Changes
Add a query for all primary bundles with a project shortname that begins with "prod"