### PR TITLE
Fix linting tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ jobs:
     - stage: Linting Test
       script: 
         # Check Black code style compliance
-        - black lira/ scripts/ --skip-string-normalization --check
+        - black ./ --skip-string-normalization --check
         # Check PEP-8 compliance
-        - flake8 lira/ scripts/
+        - flake8
 
     # The unit test is a bit more expensive so run it only
     # if the linting test passes


### PR DESCRIPTION
### Purpose
The `scripts` directory was deleted, so the formatting check `black lira/ scripts/ --skip-string-normalization --check` throws an error

### Changes
Remove the `scripts` directory from the linting check
