### PR TITLE
Make subscriptions to test data more specific

### DIFF
--- a/subscription/elasticsearch_queries/prod-test-data/10x-test-data.json
+++ b/subscription/elasticsearch_queries/prod-test-data/10x-test-data.json
@@ -1,0 +1,20 @@
+{
+  "query": {
+    "bool": {
+      "should": [
+        {
+          "prefix": {
+            "files.project_json.project_core.project_short_name": "prod/optimus/"
+          }
+        }
+      ],
+      "must_not": [
+        {
+          "match": {
+            "files.analysis_process_json.type.text": "analysis"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/subscription/elasticsearch_queries/prod-test-data/smartseq2-test-data.json
+++ b/subscription/elasticsearch_queries/prod-test-data/smartseq2-test-data.json
@@ -4,7 +4,7 @@
       "should": [
         {
           "prefix": {
-            "files.project_json.project_core.project_short_name": "prod"
+            "files.project_json.project_core.project_short_name": "prod/Smart-seq2/"
           }
         }
       ],


### PR DESCRIPTION
The subscription queries need to be pipeline-specific so that the correct pipeline is run off of the
notification! 