### PR TITLE
Modifying subscriptions to DSS to filter bundles such that bundles th…

### DIFF
--- a/subscription/elasticsearch_queries/10x-query.json
+++ b/subscription/elasticsearch_queries/10x-query.json
@@ -149,24 +149,6 @@
                   "must": [
                     {
                       "term": {
-                        "files.analysis_file_json.provenance.schema_major_version": 6
-                      }
-                    }
-                  ]
-                }
-              }
-            ],
-            "minimum_should_match": 1
-          }
-        },
-        {
-          "bool": {
-            "should": [
-              {
-                "bool": {
-                  "must": [
-                    {
-                      "term": {
                         "files.reference_file_json.provenance.schema_major_version": 3
                       }
                     }
@@ -240,24 +222,6 @@
                     {
                       "term": {
                         "files.protocol_json.provenance.schema_major_version": 7
-                      }
-                    }
-                  ]
-                }
-              }
-            ],
-            "minimum_should_match": 1
-          }
-        },
-        {
-          "bool": {
-            "should": [
-              {
-                "bool": {
-                  "must": [
-                    {
-                      "term": {
-                        "files.analysis_protocol_json.provenance.schema_major_version": 9
                       }
                     }
                   ]
@@ -474,24 +438,6 @@
                     {
                       "term": {
                         "files.process_json.provenance.schema_major_version": 9
-                      }
-                    }
-                  ]
-                }
-              }
-            ],
-            "minimum_should_match": 1
-          }
-        },
-        {
-          "bool": {
-            "should": [
-              {
-                "bool": {
-                  "must": [
-                    {
-                      "term": {
-                        "files.analysis_process_json.provenance.schema_major_version": 9
                       }
                     }
                   ]

--- a/subscription/elasticsearch_queries/10x-query.json
+++ b/subscription/elasticsearch_queries/10x-query.json
@@ -38,6 +38,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.donor_organism_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -54,6 +63,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.specimen_from_organism_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -74,6 +92,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.cell_suspension_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -90,6 +117,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.cell_line_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -110,6 +146,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.organoid_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -126,6 +171,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.imaged_specimen_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -146,6 +200,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.reference_file_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -162,6 +225,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.sequence_file_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -182,6 +254,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.supplementary_file_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -198,6 +279,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.image_file_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -218,6 +308,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -234,6 +333,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.aggregate_generation_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -254,6 +362,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.collection_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -270,6 +387,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.differentiation_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -290,6 +416,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.dissociation_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -306,6 +441,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.enrichment_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -326,6 +470,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.ipsc_induction_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -342,6 +495,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.imaging_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -362,6 +524,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.library_preparation_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -378,6 +549,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.sequencing_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -398,6 +578,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.imaging_preparation_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -414,6 +603,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.project_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -434,6 +632,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.process_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -450,6 +657,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.dissociation_process_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -470,6 +686,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.enrichment_process_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -488,6 +713,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.library_preparation_process_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -504,6 +738,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.sequencing_process_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [

--- a/subscription/elasticsearch_queries/10x-query.json
+++ b/subscription/elasticsearch_queries/10x-query.json
@@ -419,7 +419,7 @@
                   "must": [
                     {
                       "term": {
-                        "files.project_json.provenance.schema_major_version": 9
+                        "files.project_json.provenance.schema_major_version": 14
                       }
                     }
                   ]

--- a/subscription/elasticsearch_queries/10x-query.json
+++ b/subscription/elasticsearch_queries/10x-query.json
@@ -32,6 +32,546 @@
               }
             ]
           }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.donor_organism_json.provenance.schema_major_version": 15
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.specimen_from_organism_json.provenance.schema_major_version": 10
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.cell_suspension_json.provenance.schema_major_version": 13
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.cell_line_json.provenance.schema_major_version": 14
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.organoid_json.provenance.schema_major_version": 11
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.imaged_specimen_json.provenance.schema_major_version": 3
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.analysis_file_json.provenance.schema_major_version": 6
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.reference_file_json.provenance.schema_major_version": 3
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.sequence_file_json.provenance.schema_major_version": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.supplementary_file_json.provenance.schema_major_version": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.image_file_json.provenance.schema_major_version": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.protocol_json.provenance.schema_major_version": 7
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.analysis_protocol_json.provenance.schema_major_version": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.aggregate_generation_protocol_json.provenance.schema_major_version": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.collection_protocol_json.provenance.schema_major_version": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.differentiation_protocol_json.provenance.schema_major_version": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.dissociation_protocol_json.provenance.schema_major_version": 6
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.enrichment_protocol_json.provenance.schema_major_version": 3
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.ipsc_induction_protocol_json.provenance.schema_major_version": 3
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.imaging_protocol_json.provenance.schema_major_version": 11
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.library_preparation_protocol_json.provenance.schema_major_version": 6
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.sequencing_protocol_json.provenance.schema_major_version": 10
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.imaging_preparation_protocol_json.provenance.schema_major_version": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.project_json.provenance.schema_major_version": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.process_json.provenance.schema_major_version": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.analysis_process_json.provenance.schema_major_version": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.dissociation_process_json.provenance.schema_major_version": 5
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.enrichment_process_json.provenance.schema_major_version": 5
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.library_preparation_process_json.provenance.schema_major_version": 5
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.sequencing_process_json.provenance.schema_major_version": 5
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
         }
       ],
       "must_not": [

--- a/subscription/elasticsearch_queries/scripts/create_dss_subscription.py
+++ b/subscription/elasticsearch_queries/scripts/create_dss_subscription.py
@@ -74,6 +74,15 @@ def generate_elastic_search_query_for_schema_versions():
       "should": [
         {
           "bool": {
+            "must_not": {
+              "exists": {
+                "field": "files.%s_json.provenance.schema_major_version"
+              }
+            }
+          }
+        },
+        {
+          "bool": {
             "must": [
               {
                 "term": {
@@ -89,6 +98,7 @@ def generate_elastic_search_query_for_schema_versions():
   },
             """
             % (
+                schema_name.value,
                 schema_name.value,
                 LATEST_SUPPORTED_MD_SCHEMA_VERSIONS[schema_name]['major'],
             )

--- a/subscription/elasticsearch_queries/scripts/create_dss_subscription.py
+++ b/subscription/elasticsearch_queries/scripts/create_dss_subscription.py
@@ -1,0 +1,217 @@
+# Script to generate the portion of the DSS subscription via ElasticSearch query based on the last known schema
+# versions that Secondary Analysis is compatible with including compatibility dependencies on Metadata API.
+
+from enum import Enum
+
+
+class MetadataSchemaName(Enum):
+    DONOR_ORGANISM = "donor_organism"
+    SPECIMEN_FROM_ORGANISM = "specimen_from_organism"
+    CELL_SUSPENSION = "cell_suspension"
+    CELL_LINE = "cell_line"
+    ORGANOID = "organoid"
+    IMAGED_SPECIMEN = "imaged_specimen"
+    ANALYSIS_FILE = "analysis_file"
+    REFERENCE_FILE = "reference_file"
+    SEQUENCE_FILE = "sequence_file"
+    SUPPLEMENTARY_FILE = "supplementary_file"
+    IMAGE_FILE = "image_file"
+    PROTOCOL = "protocol"
+    ANALYSIS_PROTOCOL = "analysis_protocol"
+    AGGREGATE_GENERATION_PROTOCOL = "aggregate_generation_protocol"
+    COLLECTION_PROTOCOL = "collection_protocol"
+    DIFFERENTIATION_PROTOCOL = "differentiation_protocol"
+    DISSOCIATION_PROTOCOL = "dissociation_protocol"
+    ENRICHMENT_PROTOCOL = "enrichment_protocol"
+    IPSC_INDUCTION_PROTOCOL = "ipsc_induction_protocol"
+    IMAGING_PROTOCOL = "imaging_protocol"
+    LIBRARY_PREPARATION_PROTOCOL = "library_preparation_protocol"
+    SEQUENCING_PROTOCOL = "sequencing_protocol"
+    IMAGING_PREPARATION_PROTOCOL = "imaging_preparation_protocol"
+    PROJECT = "project"
+    PROCESS = "process"
+    ANALYSIS_PROCESS = "analysis_process"
+    DISSOCIATION_PROCESS = "dissociation_process"
+    ENRICHMENT_PROCESS = "enrichment_process"
+    LIBRARY_PREPARATION_PROCESS = "library_preparation_process"
+    SEQUENCING_PROCESS = "sequencing_process"
+
+
+LATEST_SUPPORTED_MD_SCHEMA_VERSIONS = {
+    MetadataSchemaName.DONOR_ORGANISM: {
+        'major': 15,
+        'minor': 3
+    },
+
+    MetadataSchemaName.SPECIMEN_FROM_ORGANISM: {
+        'major': 10,
+        'minor': 2
+    },
+
+    MetadataSchemaName.CELL_SUSPENSION: {
+        'major': 13,
+        'minor': 1
+    },
+
+    MetadataSchemaName.CELL_LINE: {
+        'major': 14,
+        'minor': 3
+    },
+
+    MetadataSchemaName.ORGANOID: {
+        'major': 11,
+        'minor': 1
+    },
+
+    MetadataSchemaName.IMAGED_SPECIMEN: {
+        'major': 3,
+        'minor': 1
+    },
+
+    MetadataSchemaName.ANALYSIS_FILE: {
+        'major': 6,
+        'minor': 1
+    },
+
+    MetadataSchemaName.REFERENCE_FILE: {
+        'major': 3,
+        'minor': 1
+    },
+
+    MetadataSchemaName.SEQUENCE_FILE: {
+        'major': 9,
+        'minor': 1
+    },
+
+    MetadataSchemaName.SUPPLEMENTARY_FILE: {
+        'major': 2,
+        'minor': 1
+    },
+
+    MetadataSchemaName.IMAGE_FILE: {
+        'major': 2,
+        'minor': 1
+    },
+
+    MetadataSchemaName.PROTOCOL: {
+        'major': 7,
+        'minor': 0
+    },
+
+    MetadataSchemaName.ANALYSIS_PROTOCOL: {
+        'major': 9,
+        'minor': 0
+    },
+
+    MetadataSchemaName.AGGREGATE_GENERATION_PROTOCOL: {
+        'major': 2,
+        'minor': 0
+    },
+
+    MetadataSchemaName.COLLECTION_PROTOCOL: {
+        'major': 9,
+        'minor': 1
+    },
+
+    MetadataSchemaName.DIFFERENTIATION_PROTOCOL: {
+        'major': 2,
+        'minor': 1
+    },
+
+    MetadataSchemaName.DISSOCIATION_PROTOCOL: {
+        'major': 6,
+        'minor': 1
+    },
+
+    MetadataSchemaName.ENRICHMENT_PROTOCOL: {
+        'major': 3,
+        'minor': 0
+    },
+
+    MetadataSchemaName.IPSC_INDUCTION_PROTOCOL: {
+        'major': 3,
+        'minor': 1
+    },
+
+    MetadataSchemaName.IMAGING_PROTOCOL: {
+        'major': 11,
+        'minor': 1
+    },
+
+    MetadataSchemaName.LIBRARY_PREPARATION_PROTOCOL: {
+        'major': 6,
+        'minor': 1
+    },
+
+    MetadataSchemaName.SEQUENCING_PROTOCOL: {
+        'major': 10,
+        'minor': 0
+    },
+
+    MetadataSchemaName.IMAGING_PREPARATION_PROTOCOL: {
+        'major': 2,
+        'minor': 1
+    },
+
+    MetadataSchemaName.PROJECT: {
+        'major': 9,
+        'minor': 0
+    },
+
+    MetadataSchemaName.PROCESS: {
+        'major': 9,
+        'minor': 1
+    },
+
+    MetadataSchemaName.ANALYSIS_PROCESS: {
+        'major': 9,
+        'minor': 0
+    },
+
+    MetadataSchemaName.DISSOCIATION_PROCESS: {
+        'major': 5,
+        'minor': 1
+    },
+
+    MetadataSchemaName.ENRICHMENT_PROCESS: {
+        'major': 5,
+        'minor': 1
+    },
+
+    MetadataSchemaName.LIBRARY_PREPARATION_PROCESS: {
+        'major': 5,
+        'minor': 1
+    },
+
+    MetadataSchemaName.SEQUENCING_PROCESS: {
+        'major': 5,
+        'minor': 1
+    }
+}
+
+
+def generate_elastic_search_query_for_schema_versions():
+    for schema_name in LATEST_SUPPORTED_MD_SCHEMA_VERSIONS:
+        print("""
+{
+    "bool": {
+      "should": [
+        {
+          "bool": {
+            "must": [
+              {
+                "term": {
+                  "files.%s_json.provenance.schema_major_version": %d
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "minimum_should_match": 1
+    }
+  },
+            """ % (schema_name.value, LATEST_SUPPORTED_MD_SCHEMA_VERSIONS[schema_name]['major']))
+
+
+generate_elastic_search_query_for_schema_versions()

--- a/subscription/elasticsearch_queries/scripts/create_dss_subscription.py
+++ b/subscription/elasticsearch_queries/scripts/create_dss_subscription.py
@@ -56,7 +56,7 @@ LATEST_SUPPORTED_MD_SCHEMA_VERSIONS = {
     MetadataSchemaName.LIBRARY_PREPARATION_PROTOCOL: {'major': 6, 'minor': 1},
     MetadataSchemaName.SEQUENCING_PROTOCOL: {'major': 10, 'minor': 0},
     MetadataSchemaName.IMAGING_PREPARATION_PROTOCOL: {'major': 2, 'minor': 1},
-    MetadataSchemaName.PROJECT: {'major': 9, 'minor': 0},
+    MetadataSchemaName.PROJECT: {'major': 14, 'minor': 0},
     MetadataSchemaName.PROCESS: {'major': 9, 'minor': 1},
     MetadataSchemaName.DISSOCIATION_PROCESS: {'major': 5, 'minor': 1},
     MetadataSchemaName.ENRICHMENT_PROCESS: {'major': 5, 'minor': 1},

--- a/subscription/elasticsearch_queries/scripts/create_dss_subscription.py
+++ b/subscription/elasticsearch_queries/scripts/create_dss_subscription.py
@@ -11,13 +11,11 @@ class MetadataSchemaName(Enum):
     CELL_LINE = "cell_line"
     ORGANOID = "organoid"
     IMAGED_SPECIMEN = "imaged_specimen"
-    ANALYSIS_FILE = "analysis_file"
     REFERENCE_FILE = "reference_file"
     SEQUENCE_FILE = "sequence_file"
     SUPPLEMENTARY_FILE = "supplementary_file"
     IMAGE_FILE = "image_file"
     PROTOCOL = "protocol"
-    ANALYSIS_PROTOCOL = "analysis_protocol"
     AGGREGATE_GENERATION_PROTOCOL = "aggregate_generation_protocol"
     COLLECTION_PROTOCOL = "collection_protocol"
     DIFFERENTIATION_PROTOCOL = "differentiation_protocol"
@@ -30,7 +28,6 @@ class MetadataSchemaName(Enum):
     IMAGING_PREPARATION_PROTOCOL = "imaging_preparation_protocol"
     PROJECT = "project"
     PROCESS = "process"
-    ANALYSIS_PROCESS = "analysis_process"
     DISSOCIATION_PROCESS = "dissociation_process"
     ENRICHMENT_PROCESS = "enrichment_process"
     LIBRARY_PREPARATION_PROCESS = "library_preparation_process"
@@ -68,11 +65,6 @@ LATEST_SUPPORTED_MD_SCHEMA_VERSIONS = {
         'minor': 1
     },
 
-    MetadataSchemaName.ANALYSIS_FILE: {
-        'major': 6,
-        'minor': 1
-    },
-
     MetadataSchemaName.REFERENCE_FILE: {
         'major': 3,
         'minor': 1
@@ -95,11 +87,6 @@ LATEST_SUPPORTED_MD_SCHEMA_VERSIONS = {
 
     MetadataSchemaName.PROTOCOL: {
         'major': 7,
-        'minor': 0
-    },
-
-    MetadataSchemaName.ANALYSIS_PROTOCOL: {
-        'major': 9,
         'minor': 0
     },
 
@@ -161,11 +148,6 @@ LATEST_SUPPORTED_MD_SCHEMA_VERSIONS = {
     MetadataSchemaName.PROCESS: {
         'major': 9,
         'minor': 1
-    },
-
-    MetadataSchemaName.ANALYSIS_PROCESS: {
-        'major': 9,
-        'minor': 0
     },
 
     MetadataSchemaName.DISSOCIATION_PROCESS: {

--- a/subscription/elasticsearch_queries/scripts/create_dss_subscription.py
+++ b/subscription/elasticsearch_queries/scripts/create_dss_subscription.py
@@ -35,146 +35,40 @@ class MetadataSchemaName(Enum):
 
 
 LATEST_SUPPORTED_MD_SCHEMA_VERSIONS = {
-    MetadataSchemaName.DONOR_ORGANISM: {
-        'major': 15,
-        'minor': 3
-    },
-
-    MetadataSchemaName.SPECIMEN_FROM_ORGANISM: {
-        'major': 10,
-        'minor': 2
-    },
-
-    MetadataSchemaName.CELL_SUSPENSION: {
-        'major': 13,
-        'minor': 1
-    },
-
-    MetadataSchemaName.CELL_LINE: {
-        'major': 14,
-        'minor': 3
-    },
-
-    MetadataSchemaName.ORGANOID: {
-        'major': 11,
-        'minor': 1
-    },
-
-    MetadataSchemaName.IMAGED_SPECIMEN: {
-        'major': 3,
-        'minor': 1
-    },
-
-    MetadataSchemaName.REFERENCE_FILE: {
-        'major': 3,
-        'minor': 1
-    },
-
-    MetadataSchemaName.SEQUENCE_FILE: {
-        'major': 9,
-        'minor': 1
-    },
-
-    MetadataSchemaName.SUPPLEMENTARY_FILE: {
-        'major': 2,
-        'minor': 1
-    },
-
-    MetadataSchemaName.IMAGE_FILE: {
-        'major': 2,
-        'minor': 1
-    },
-
-    MetadataSchemaName.PROTOCOL: {
-        'major': 7,
-        'minor': 0
-    },
-
-    MetadataSchemaName.AGGREGATE_GENERATION_PROTOCOL: {
-        'major': 2,
-        'minor': 0
-    },
-
-    MetadataSchemaName.COLLECTION_PROTOCOL: {
-        'major': 9,
-        'minor': 1
-    },
-
-    MetadataSchemaName.DIFFERENTIATION_PROTOCOL: {
-        'major': 2,
-        'minor': 1
-    },
-
-    MetadataSchemaName.DISSOCIATION_PROTOCOL: {
-        'major': 6,
-        'minor': 1
-    },
-
-    MetadataSchemaName.ENRICHMENT_PROTOCOL: {
-        'major': 3,
-        'minor': 0
-    },
-
-    MetadataSchemaName.IPSC_INDUCTION_PROTOCOL: {
-        'major': 3,
-        'minor': 1
-    },
-
-    MetadataSchemaName.IMAGING_PROTOCOL: {
-        'major': 11,
-        'minor': 1
-    },
-
-    MetadataSchemaName.LIBRARY_PREPARATION_PROTOCOL: {
-        'major': 6,
-        'minor': 1
-    },
-
-    MetadataSchemaName.SEQUENCING_PROTOCOL: {
-        'major': 10,
-        'minor': 0
-    },
-
-    MetadataSchemaName.IMAGING_PREPARATION_PROTOCOL: {
-        'major': 2,
-        'minor': 1
-    },
-
-    MetadataSchemaName.PROJECT: {
-        'major': 9,
-        'minor': 0
-    },
-
-    MetadataSchemaName.PROCESS: {
-        'major': 9,
-        'minor': 1
-    },
-
-    MetadataSchemaName.DISSOCIATION_PROCESS: {
-        'major': 5,
-        'minor': 1
-    },
-
-    MetadataSchemaName.ENRICHMENT_PROCESS: {
-        'major': 5,
-        'minor': 1
-    },
-
-    MetadataSchemaName.LIBRARY_PREPARATION_PROCESS: {
-        'major': 5,
-        'minor': 1
-    },
-
-    MetadataSchemaName.SEQUENCING_PROCESS: {
-        'major': 5,
-        'minor': 1
-    }
+    MetadataSchemaName.DONOR_ORGANISM: {'major': 15, 'minor': 3},
+    MetadataSchemaName.SPECIMEN_FROM_ORGANISM: {'major': 10, 'minor': 2},
+    MetadataSchemaName.CELL_SUSPENSION: {'major': 13, 'minor': 1},
+    MetadataSchemaName.CELL_LINE: {'major': 14, 'minor': 3},
+    MetadataSchemaName.ORGANOID: {'major': 11, 'minor': 1},
+    MetadataSchemaName.IMAGED_SPECIMEN: {'major': 3, 'minor': 1},
+    MetadataSchemaName.REFERENCE_FILE: {'major': 3, 'minor': 1},
+    MetadataSchemaName.SEQUENCE_FILE: {'major': 9, 'minor': 1},
+    MetadataSchemaName.SUPPLEMENTARY_FILE: {'major': 2, 'minor': 1},
+    MetadataSchemaName.IMAGE_FILE: {'major': 2, 'minor': 1},
+    MetadataSchemaName.PROTOCOL: {'major': 7, 'minor': 0},
+    MetadataSchemaName.AGGREGATE_GENERATION_PROTOCOL: {'major': 2, 'minor': 0},
+    MetadataSchemaName.COLLECTION_PROTOCOL: {'major': 9, 'minor': 1},
+    MetadataSchemaName.DIFFERENTIATION_PROTOCOL: {'major': 2, 'minor': 1},
+    MetadataSchemaName.DISSOCIATION_PROTOCOL: {'major': 6, 'minor': 1},
+    MetadataSchemaName.ENRICHMENT_PROTOCOL: {'major': 3, 'minor': 0},
+    MetadataSchemaName.IPSC_INDUCTION_PROTOCOL: {'major': 3, 'minor': 1},
+    MetadataSchemaName.IMAGING_PROTOCOL: {'major': 11, 'minor': 1},
+    MetadataSchemaName.LIBRARY_PREPARATION_PROTOCOL: {'major': 6, 'minor': 1},
+    MetadataSchemaName.SEQUENCING_PROTOCOL: {'major': 10, 'minor': 0},
+    MetadataSchemaName.IMAGING_PREPARATION_PROTOCOL: {'major': 2, 'minor': 1},
+    MetadataSchemaName.PROJECT: {'major': 9, 'minor': 0},
+    MetadataSchemaName.PROCESS: {'major': 9, 'minor': 1},
+    MetadataSchemaName.DISSOCIATION_PROCESS: {'major': 5, 'minor': 1},
+    MetadataSchemaName.ENRICHMENT_PROCESS: {'major': 5, 'minor': 1},
+    MetadataSchemaName.LIBRARY_PREPARATION_PROCESS: {'major': 5, 'minor': 1},
+    MetadataSchemaName.SEQUENCING_PROCESS: {'major': 5, 'minor': 1},
 }
 
 
 def generate_elastic_search_query_for_schema_versions():
     for schema_name in LATEST_SUPPORTED_MD_SCHEMA_VERSIONS:
-        print("""
+        print(
+            """
 {
     "bool": {
       "should": [
@@ -193,7 +87,12 @@ def generate_elastic_search_query_for_schema_versions():
       "minimum_should_match": 1
     }
   },
-            """ % (schema_name.value, LATEST_SUPPORTED_MD_SCHEMA_VERSIONS[schema_name]['major']))
+            """
+            % (
+                schema_name.value,
+                LATEST_SUPPORTED_MD_SCHEMA_VERSIONS[schema_name]['major'],
+            )
+        )
 
 
 generate_elastic_search_query_for_schema_versions()

--- a/subscription/elasticsearch_queries/smartseq2-query.json
+++ b/subscription/elasticsearch_queries/smartseq2-query.json
@@ -22,6 +22,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.donor_organism_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -38,6 +47,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.specimen_from_organism_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -58,6 +76,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.cell_suspension_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -74,6 +101,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.cell_line_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -94,6 +130,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.organoid_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -110,6 +155,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.imaged_specimen_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -130,6 +184,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.reference_file_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -146,6 +209,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.sequence_file_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -166,6 +238,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.supplementary_file_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -182,6 +263,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.image_file_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -202,6 +292,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -218,6 +317,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.aggregate_generation_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -238,6 +346,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.collection_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -254,6 +371,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.differentiation_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -274,6 +400,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.dissociation_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -290,6 +425,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.enrichment_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -310,6 +454,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.ipsc_induction_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -326,6 +479,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.imaging_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -346,6 +508,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.library_preparation_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -362,6 +533,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.sequencing_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -382,6 +562,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.imaging_preparation_protocol_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -398,6 +587,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.project_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -418,6 +616,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.process_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -434,6 +641,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.dissociation_process_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [
@@ -454,6 +670,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.enrichment_process_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -472,6 +697,15 @@
             "should": [
               {
                 "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.library_preparation_process_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
+              {
+                "bool": {
                   "must": [
                     {
                       "term": {
@@ -488,6 +722,15 @@
         {
           "bool": {
             "should": [
+              {
+                "bool": {
+                  "must_not": {
+                    "exists": {
+                      "field": "files.sequencing_process_json.provenance.schema_major_version"
+                    }
+                  }
+                }
+              },
               {
                 "bool": {
                   "must": [

--- a/subscription/elasticsearch_queries/smartseq2-query.json
+++ b/subscription/elasticsearch_queries/smartseq2-query.json
@@ -5,7 +5,6 @@
         {
           "match": {
             "files.library_preparation_protocol_json.library_construction_method.ontology": "EFO:0008931"
-
           }
         },
         {
@@ -16,6 +15,546 @@
         {
           "match": {
             "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": 9606
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.donor_organism_json.provenance.schema_major_version": 15
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.specimen_from_organism_json.provenance.schema_major_version": 10
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.cell_suspension_json.provenance.schema_major_version": 13
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.cell_line_json.provenance.schema_major_version": 14
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.organoid_json.provenance.schema_major_version": 11
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.imaged_specimen_json.provenance.schema_major_version": 3
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.analysis_file_json.provenance.schema_major_version": 6
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.reference_file_json.provenance.schema_major_version": 3
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.sequence_file_json.provenance.schema_major_version": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.supplementary_file_json.provenance.schema_major_version": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.image_file_json.provenance.schema_major_version": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.protocol_json.provenance.schema_major_version": 7
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.analysis_protocol_json.provenance.schema_major_version": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.aggregate_generation_protocol_json.provenance.schema_major_version": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.collection_protocol_json.provenance.schema_major_version": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.differentiation_protocol_json.provenance.schema_major_version": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.dissociation_protocol_json.provenance.schema_major_version": 6
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.enrichment_protocol_json.provenance.schema_major_version": 3
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.ipsc_induction_protocol_json.provenance.schema_major_version": 3
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.imaging_protocol_json.provenance.schema_major_version": 11
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.library_preparation_protocol_json.provenance.schema_major_version": 6
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.sequencing_protocol_json.provenance.schema_major_version": 10
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.imaging_preparation_protocol_json.provenance.schema_major_version": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.project_json.provenance.schema_major_version": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.process_json.provenance.schema_major_version": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.analysis_process_json.provenance.schema_major_version": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.dissociation_process_json.provenance.schema_major_version": 5
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.enrichment_process_json.provenance.schema_major_version": 5
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.library_preparation_process_json.provenance.schema_major_version": 5
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "files.sequencing_process_json.provenance.schema_major_version": 5
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "minimum_should_match": 1
           }
         }
       ],
@@ -36,7 +575,7 @@
           "match": {
             "files.analysis_process_json.type.text": "analysis"
           }
-        }, 
+        },
         {
           "range": {
             "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": {

--- a/subscription/elasticsearch_queries/smartseq2-query.json
+++ b/subscription/elasticsearch_queries/smartseq2-query.json
@@ -133,24 +133,6 @@
                   "must": [
                     {
                       "term": {
-                        "files.analysis_file_json.provenance.schema_major_version": 6
-                      }
-                    }
-                  ]
-                }
-              }
-            ],
-            "minimum_should_match": 1
-          }
-        },
-        {
-          "bool": {
-            "should": [
-              {
-                "bool": {
-                  "must": [
-                    {
-                      "term": {
                         "files.reference_file_json.provenance.schema_major_version": 3
                       }
                     }
@@ -224,24 +206,6 @@
                     {
                       "term": {
                         "files.protocol_json.provenance.schema_major_version": 7
-                      }
-                    }
-                  ]
-                }
-              }
-            ],
-            "minimum_should_match": 1
-          }
-        },
-        {
-          "bool": {
-            "should": [
-              {
-                "bool": {
-                  "must": [
-                    {
-                      "term": {
-                        "files.analysis_protocol_json.provenance.schema_major_version": 9
                       }
                     }
                   ]
@@ -458,24 +422,6 @@
                     {
                       "term": {
                         "files.process_json.provenance.schema_major_version": 9
-                      }
-                    }
-                  ]
-                }
-              }
-            ],
-            "minimum_should_match": 1
-          }
-        },
-        {
-          "bool": {
-            "should": [
-              {
-                "bool": {
-                  "must": [
-                    {
-                      "term": {
-                        "files.analysis_process_json.provenance.schema_major_version": 9
                       }
                     }
                   ]

--- a/subscription/elasticsearch_queries/smartseq2-query.json
+++ b/subscription/elasticsearch_queries/smartseq2-query.json
@@ -403,7 +403,7 @@
                   "must": [
                     {
                       "term": {
-                        "files.project_json.provenance.schema_major_version": 9
+                        "files.project_json.provenance.schema_major_version": 14
                       }
                     }
                   ]


### PR DESCRIPTION
…at have a version that is less than or equal to the current latest metadata schema versions are accepted or if the schema version is not populated. Also added a script to generate the query.

### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->
The purpose of this PR is to enable the metadata schema unfreeze so that schema changes can be pushed to production without breaking downstream components.

https://app.zenhub.com/workspaces/dcp-5ac7bcf9465cb172b77760d9/issues/humancellatlas/secondary-analysis/631

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Secondary Analysis will not be notified when bundles are created including metadata above a version that SA is currently capable of handling including via Metadata API dependencies.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Please test that you are able to receive bundle with ID 1db5775c-a8bd-4f6f-acb6-9233b129f404 in integration environment.
