### PR TITLE
Add data store notifications to pub/sub queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ python:
 
 install: "pip install -r requirements.txt"
 
+before_install:
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools
+
 jobs:
   include:
     # The linting test is fast and cheap so run it first

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -33,7 +33,7 @@ def post(body):
     topic_name = 'hca-notifications-dev'
     publisher = pubsub_v1.PublisherClient.from_service_account_file(lira_config.caas_key)
     topic_path = publisher.topic_path(project_id, topic_name)
-    message = body.encode('utf-8')
+    message = json.dumps(body).encode('utf-8')
     future = publisher.publish(
         topic_path, message, origin='lira-dev'
     )

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -172,4 +172,3 @@ def submit_workflow(message):
             )
             status_code = 201
     return lira_utils.response_with_server_header(response_json, status_code)
-

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -48,8 +48,8 @@ def receive_messages():
     #         current_app.config['PUBSUB_VERIFICATION_TOKEN']):
     #     return 'Invalid request', 400
     envelope = json.loads(request.data.decode('utf-8'))
-    data = base64.b64decode(envelope['message']['data'])
-    logger.info(data)
+    message = base64.b64decode(envelope['message'])
+    logger.info(message)
     # response = submit_workflow(data)
     # return response
 

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -116,7 +116,7 @@ def submit_workflow(message):
         labels_from_notification,
         attachments_from_notification,
         workflow_hash_label,
-        message_id_label
+        message_id_label,
     )
     cromwell_labels_file = json.dumps(cromwell_labels).encode('utf-8')
 

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -37,7 +37,7 @@ def post(body):
     topic_path = publisher.topic_path(project_id, topic_name)
     message = json.dumps(body).encode("utf-8")
     future = publisher.publish(topic_path, message, origin=f"lira-{lira_config.env}")
-    message_id = future.result(timeout=60)
+    message_id = future.result(timeout=60)  # Wait 60s for a value to be returned, otherwise raise a timeout error
     logger.info(f"Message {message_id} added to topic {topic_name}")
     return lira_utils.response_with_server_header({"id": message_id}, 200)
 

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -30,13 +30,13 @@ def post(body):
     logger.info(f"Received notification body: {body}")
 
     project_id = lira_config.google_project
-    topic_name = "hca-notifications-dev"
+    topic_name = lira_config.google_pubsub_topic
     publisher = pubsub_v1.PublisherClient.from_service_account_file(
         lira_config.caas_key
     )
     topic_path = publisher.topic_path(project_id, topic_name)
     message = json.dumps(body).encode("utf-8")
-    future = publisher.publish(topic_path, message, origin="lira-dev")
+    future = publisher.publish(topic_path, message, origin=f"lira-{lira_config.env}")
     message_id = future.result()
     logger.info(f"Message {message_id} added to topic {topic_name}")
     return lira_utils.response_with_server_header({"id": message_id}, 200)

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -47,10 +47,10 @@ def receive_messages(body):
     # if (request.args.get('token', '') !=
     #         current_app.config['PUBSUB_VERIFICATION_TOKEN']):
     #     return 'Invalid request', 400
-    logger.info(request.data)
+    # logger.info(request.data)
     logger.info(body)
-    envelope = json.loads(request.data.decode('utf-8'))
-    message = envelope['message']
+    # envelope = json.loads(request.data.decode('utf-8'))
+    message = body['message']
     logger.info(f"Received message from Google pub/sub: {message}")
     response = submit_workflow(message)
     return response
@@ -58,7 +58,8 @@ def receive_messages(body):
 
 def submit_workflow(message):
     lira_config = current_app.config
-    body = base64.b64decode(message['data'])
+    data = base64.b64decode(message['data'])
+    body = json.loads(data)
     uuid, version, subscription_id = lira_utils.extract_uuid_version_subscription_id(
         body
     )

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -37,7 +37,7 @@ def post(body):
     topic_path = publisher.topic_path(project_id, topic_name)
     message = json.dumps(body).encode("utf-8")
     future = publisher.publish(topic_path, message, origin=f"lira-{lira_config.env}")
-    message_id = future.result()
+    message_id = future.result(timeout=60)
     logger.info(f"Message {message_id} added to topic {topic_name}")
     return lira_utils.response_with_server_header({"id": message_id}, 200)
 

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -42,11 +42,13 @@ def post(body):
     return lira_utils.response_with_server_header({"id": message_id}, 200)
 
 
-def receive_messages():
+def receive_messages(body):
     """Receive and process messages from Google pub/sub topic."""
     # if (request.args.get('token', '') !=
     #         current_app.config['PUBSUB_VERIFICATION_TOKEN']):
     #     return 'Invalid request', 400
+    logger.info(request.data)
+    logger.info(body)
     envelope = json.loads(request.data.decode('utf-8'))
     message = envelope['message']
     logger.info(f"Received message from Google pub/sub: {message}")

--- a/lira/bundle_inputs.py
+++ b/lira/bundle_inputs.py
@@ -1,0 +1,44 @@
+import hashlib
+from pipeline_tools.pipelines.smartseq2 import smartseq2
+from pipeline_tools.pipelines.optimus import optimus
+
+WORKFLOW_INPUTS = {
+    'AdapterSmartSeq2SingleCell': smartseq2.get_ss2_paired_end_inputs_to_hash,
+    'AdapterOptimus': optimus.get_optimus_inputs_to_hash,
+}
+
+
+def get_workflow_inputs_to_hash(workflow_name, bundle_id, bundle_version, dss_url):
+    """
+    Get the bundle-specific inputs for a workflow.
+
+    Args:
+        workflow_name (str): The name of the WDL workflow
+        bundle_id (str): The UUID of the HCA data bundle
+        bundle_version (str): The version timestamp of the HCA data bundle
+        dss_url (str): The URL to a particular HCA Data Store environment
+
+    Returns:
+        dict: A dictionary of {'hash-id': <SHA-256 hexadecimal hash>}
+    """
+    get_inputs_to_hash = WORKFLOW_INPUTS.get(workflow_name, None)
+    if get_inputs_to_hash:
+        workflow_inputs = get_inputs_to_hash(bundle_id, bundle_version, dss_url)
+        workflow_inputs_hash = get_hash_id(workflow_inputs)
+        return {'hash-id': workflow_inputs_hash}
+
+
+def get_hash_id(workflow_inputs):
+    """
+    Create a SHA-256 hash of the values in workflow_inputs.
+
+    Args:
+        workflow_inputs (tuple): Tuple of bundle-specific inputs to the workflow
+
+    Returns:
+        str: SHA-256 hexadecimal hash
+    """
+    sha256_hash = hashlib.sha256(
+        bytes(''.join((str(i) for i in workflow_inputs)), encoding='utf-8')
+    )
+    return sha256_hash.hexdigest()

--- a/lira/lira_api.yml
+++ b/lira/lira_api.yml
@@ -62,10 +62,11 @@ paths:
     post:
       tags:
       - "Lira"
-      summary: "Listen for notifications and start workflows"
+      summary: "Listen for notifications and add to queue"
       description: |
-        Listen for notifications and process them in order to start analysis workflows.
+        Listen for notifications and add them to a Google pub/sub queue.
         The notifications should contain HCA DCP Bundle information and be authenticated.
+      operationId: 'lira.api.notifications.post'
       consumes:
         - application/json
       parameters:
@@ -79,6 +80,28 @@ paths:
           description: "OK"
           schema:
             $ref: '#/definitions/NotificationResponse'
+        # Definition of all error statuses
+        default:
+          description: "Unexpected Error"
+          schema:
+            $ref: '#/definitions/Error'
+  /submissions:
+    post:
+      tags:
+       - "Lira"
+      summary: "Receives messages from queue and submits a workflow to Cromwell."
+      description: |
+              Receives messages from Google pub/sub topic, processes the HCA DCP
+              Bundle information in the message, and submits an on-hold workflow
+              to Cromwell.
+      operationId: 'lira.api.notifications.receive_messages'
+      consumes:
+        - application/json
+      responses:
+        201:
+          description: "OK"
+          schema:
+            $ref: '#/definitions/CromwellSubmissionResponse'
         # Definition of all error statuses
         default:
           description: "Unexpected Error"
@@ -157,11 +180,18 @@ definitions:
   NotificationResponse:
     type: object
     properties:
+      id:
+        description: "ID of the Google pub/sub message"
+        type: string
+        example: "3fa85f64"
+  CromwellSubmissionResponse:
+    type: object
+    properties:
       status:
         type: string
         example: "Submitted"
       id:
-        description: "UUID of the started workflow"
+        description: "UUID of the submitted Cromwell workflow"
         type: string
         example: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
   HealthCheckResponse:

--- a/lira/lira_api.yml
+++ b/lira/lira_api.yml
@@ -254,6 +254,7 @@ definitions:
             example: "v1.0.0"
           lira_version:
             type: string
+            pattern: '(v)?([0-9]+)\.([0-9]+)\.([0-9]+)'
             example: "v1.0.0"
           submit_wdl_version:
             type: string

--- a/lira/lira_api.yml
+++ b/lira/lira_api.yml
@@ -76,7 +76,7 @@ paths:
           schema:
             $ref: '#/definitions/Notification'
       responses:
-        201:
+        200:
           description: "OK"
           schema:
             $ref: '#/definitions/NotificationResponse'

--- a/lira/lira_api.yml
+++ b/lira/lira_api.yml
@@ -97,6 +97,12 @@ paths:
       operationId: 'lira.api.notifications.receive_messages'
       consumes:
         - application/json
+      parameters:
+        - name: body
+          in: body
+          required: false
+          schema:
+            $ref: '#/definitions/PubSubMessage'
       responses:
         201:
           description: "OK"
@@ -133,6 +139,16 @@ definitions:
       - subscription_id
       - transaction_id
       - match
+  PubSubMessage:
+    type: object
+    properties:
+      message:
+        $ref: '#/definitions/Message'
+  Message:
+    type: object
+    properties:
+      data:
+        type: string
   Match:
     type: object
     properties:

--- a/lira/lira_api.yml
+++ b/lira/lira_api.yml
@@ -254,7 +254,6 @@ definitions:
             example: "v1.0.0"
           lira_version:
             type: string
-            pattern: '(v)?([0-9]+)\.([0-9]+)\.([0-9]+)'
             example: "v1.0.0"
           submit_wdl_version:
             type: string

--- a/lira/lira_config.py
+++ b/lira/lira_config.py
@@ -182,25 +182,23 @@ class LiraConfig(Config):
             self.log_level_connexion_validation
         )
 
+        env = config_object.get('env')
+        if not config_object.get('google_pubsub_topic'):
+            self.google_pubsub_topic = f'hca-notifications-{env}'
+
         # Check cromwell credentials
         use_caas = config_object.get('use_caas', None)
         if not use_caas:
             config_object['use_caas'] = False
         if config_object.get('use_caas'):
             if not config_object.get('collection_name'):
-                self.collection_name = 'lira-{}-workflows'.format(
-                    config_object.get('env')
-                )
+                self.collection_name = f'lira-{env}-workflows'
             caas_key = os.environ.get('caas_key')
             if not caas_key:
                 raise ValueError(
                     'No service account json key provided for cromwell-as-a-service.'
                 )
             self.caas_key = caas_key
-            if not config_object.get('google_project'):
-                raise ValueError(
-                    'No google_project specified. You must specify a project for workflows to run in when using CaaS.'
-                )
             if not config_object.get('gcs_root'):
                 raise ValueError(
                     'No gcs_root specified. You must specify a GCS path for workflow outputs to be written to when using CaaS.'
@@ -263,6 +261,7 @@ class LiraConfig(Config):
             'ingest_url',
             'schema_url',
             'DOMAIN',
+            'google_project'
         }
 
     @staticmethod
@@ -280,7 +279,20 @@ class LiraConfig(Config):
             )
 
     def __str__(self):
-        s = 'LiraConfig({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})'
+        s = (
+            'LiraConfig(environment: {0},'
+            ' submit_wdl: {1},'
+            ' cromwell_url: {2},'
+            ' use_caas: {3},'
+            ' MAX_CONTENT_LENGTH: {4},'
+            ' wdls: {5},'
+            ' lira_version: {6},'
+            ' dss_url: {7},'
+            ' ingest_url: {8},'
+            ' schema_url: {9},'
+            ' DOMAIN: {10},'
+            ' google_project: {11}'
+        )
         return s.format(
             self.env,
             self.submit_wdl,
@@ -293,6 +305,7 @@ class LiraConfig(Config):
             self.ingest_url,
             self.schema_url,
             self.DOMAIN,
+            self.google_project
         )
 
     def __repr__(self):
@@ -303,11 +316,12 @@ class LiraConfig(Config):
             ' use_caas: {3},'
             ' MAX_CONTENT_LENGTH: {4},'
             ' wdls: {5},'
-            ' lira_version: {6}'
-            ' dss_url: {7}'
-            ' ingest_url: {8}'
-            ' schema_url: {9}'
-            ' DOMAIN: {10}'
+            ' lira_version: {6},'
+            ' dss_url: {7},'
+            ' ingest_url: {8},'
+            ' schema_url: {9},'
+            ' DOMAIN: {10},'
+            ' google_project: {11}'
         )
         return s.format(
             self.env,
@@ -321,6 +335,7 @@ class LiraConfig(Config):
             self.ingest_url,
             self.schema_url,
             self.DOMAIN,
+            self.google_project
         )
 
 

--- a/lira/lira_config.py
+++ b/lira/lira_config.py
@@ -261,7 +261,7 @@ class LiraConfig(Config):
             'ingest_url',
             'schema_url',
             'DOMAIN',
-            'google_project'
+            'google_project',
         }
 
     @staticmethod
@@ -305,7 +305,7 @@ class LiraConfig(Config):
             self.ingest_url,
             self.schema_url,
             self.DOMAIN,
-            self.google_project
+            self.google_project,
         )
 
     def __repr__(self):
@@ -335,7 +335,7 @@ class LiraConfig(Config):
             self.ingest_url,
             self.schema_url,
             self.DOMAIN,
-            self.google_project
+            self.google_project,
         )
 
 

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -11,6 +11,8 @@ import base64
 import email.utils
 from datetime import datetime, timedelta, timezone
 import cromwell_tools
+from google.oauth2 import id_token
+from google.auth.transport import requests as google_transport_requests
 
 
 logger = logging.getLogger(f'lira.{__name__}')
@@ -18,6 +20,26 @@ logger = logging.getLogger(f'lira.{__name__}')
 
 LIRA_SERVER_HEADER = {'Server': 'Lira Service', 'Content-type': 'application/json'}
 
+
+def _is_authenticated_pubsub(request):
+    """ Check if the message is sent by Google:
+    https://google-auth.readthedocs.io/en/latest/reference/google.oauth2.id_token.html """
+    try:
+        # Get the Cloud Pub/Sub-generated JWT in the "Authorization" header.
+        bearer_token = request.headers.get('Authorization')
+        token = bearer_token.split(' ')[1]
+
+        # Verify and decode the JWT. `verify_oauth2_token` verifies
+        # the JWT signature, the `aud` claim, and the `exp` claim.
+        claim = id_token.verify_oauth2_token(token, google_transport_requests.Request())
+        # Must also verify the `iss` claim.
+        if claim['iss'] not in ['accounts.google.com', 'https://accounts.google.com']:
+            logger.error('Wrong issuer.')
+            return False
+        return True
+    except Exception as e:
+        logger.error('Invalid token: {}\n'.format(e))
+        return False
 
 def response_with_server_header(body, status):
     """Add information of server to header.

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -41,6 +41,7 @@ def _is_authenticated_pubsub(request):
         logger.error(f'Invalid token: {e}\n')
         return False
 
+
 def response_with_server_header(body, status):
     """Add information of server to header.
 

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -38,7 +38,7 @@ def _is_authenticated_pubsub(request):
             return False
         return True
     except Exception as e:
-        logger.error('Invalid token: {}\n'.format(e))
+        logger.error(f'Invalid token: {e}\n')
         return False
 
 def response_with_server_header(body, status):

--- a/lira/test/data/config.json
+++ b/lira/test/data/config.json
@@ -1,6 +1,7 @@
 {
   "version": "v0.1.0",
   "env": "dev",
+  "google_project": "broad-dsde-mint-dev",
   "cromwell_url": "https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1",
   "cromwell_user": "test",
   "cromwell_password": "test",

--- a/lira/test/test_bundle_inputs.py
+++ b/lira/test/test_bundle_inputs.py
@@ -1,0 +1,56 @@
+import hashlib
+import unittest
+from lira import bundle_inputs
+from pipeline_tools.shared.metadata_utils import get_hashes_from_file_manifest
+from humancellatlas.data.metadata.api import ManifestEntry
+
+
+class TestGetBundleInputs(unittest.TestCase):
+    def setUp(self):
+        self.workflow_name = 'AdapterSmartSeq2SingleCell'
+        self.sample_id = 'sample_id'
+        self.taxon_id = 'taxon_id'
+        self.fastq1_manifest = ManifestEntry(
+            url='gs://foo/read1.fastq',
+            sha1='sha1_read1',
+            sha256='sha256_read1',
+            s3_etag='s3_etag_read1',
+            crc32c='crc32c_read1',
+            uuid='1',
+            version='v1',
+            size='100',
+            name='read1.fastq',
+            indexed=True,
+            content_type='fastq',
+        )
+        self.fastq2_manifest = ManifestEntry(
+            url='gs://foo/read2.fastq',
+            sha1='sha1_read2',
+            sha256='sha256_read2',
+            s3_etag='s3_etag_read2',
+            crc32c='crc32c_read2',
+            uuid='2',
+            version='v1',
+            size='100',
+            name='read2.fastq',
+            indexed=True,
+            content_type='fastq',
+        )
+        self.r1_file_hashes = get_hashes_from_file_manifest(self.fastq1_manifest)
+        self.r2_file_hashes = get_hashes_from_file_manifest(self.fastq2_manifest)
+
+    def test_get_hash_id(self):
+        workflow_inputs = (
+            self.sample_id,
+            self.taxon_id,
+            self.r1_file_hashes,
+            self.r2_file_hashes,
+        )
+        workflow_inputs_hash = bundle_inputs.get_hash_id(workflow_inputs)
+        expected_hash = hashlib.sha256(
+            bytes(
+                f'{self.sample_id}{self.taxon_id}{self.r1_file_hashes}{self.r2_file_hashes}',
+                encoding='utf-8',
+            )
+        )
+        self.assertEquals(workflow_inputs_hash, expected_hash.hexdigest())

--- a/lira/test/test_config.py
+++ b/lira/test/test_config.py
@@ -143,13 +143,6 @@ class TestStartupVerification(unittest.TestCase):
         config = lira_config.LiraConfig(test_config)
         self.assertTrue(config.use_caas)
 
-    def test_using_caas_requires_google_project(self):
-        test_config = deepcopy(self.correct_test_config)
-        test_config['use_caas'] = 'true'
-        test_config['gcs_root'] = 'fake gcs root'
-        with self.assertRaises(ValueError):
-            config = lira_config.LiraConfig(test_config)
-
     def test_using_caas_requires_gcs_root(self):
         test_config = deepcopy(self.correct_test_config)
         test_config['use_caas'] = 'true'

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ black==19.3b0
 flake8==3.7.7
 pre-commit==1.14.4
 google-cloud-pubsub==0.39.1
+git+git://github.com/HumanCellAtlas/pipeline-tools@v0.56.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ cromwell-tools>=1.1.1, <2
 black==19.3b0
 flake8==3.7.7
 pre-commit==1.14.4
+google-cloud-pubsub==0.39.1

--- a/start_lira.sh
+++ b/start_lira.sh
@@ -14,17 +14,17 @@ fi
 #   requests will break/block the main process and cause CRITICAL TIMEOUTS problems.
 #   The command will try to get the (2 * current number of CPU cores) + 1 first, if it failed, it will use 5 as the
 #   the number of workers, for portability purposes.
-#--timeout: by default, it's set to 30s, which is not enough for some of the requests that are sent to Cromwell.
-#   It's set to 60 seconds now, which is consistent with the response timeout(NOT the health check timeout) of
+#--timeout: by default, it's set to 30s, which is not enough for some of the requests that are sent to Cromwell or the
+#   HCA Data Store. It's set to 180 seconds now, which is consistent with the response timeout(NOT the health check timeout) of
 #   our GKE Load Balancer.
 #--graceful-timeout: by default, it's set to 30s, this parameter helps the workers reboot gracefully,
-#   instead of shutting down immediately. It's set to 60s now to be consistent with the timeouts.
+#   instead of shutting down immediately. It's set to 180s now to be consistent with the timeouts.
 #--worker-class: this is the critical parameter that controls the working pattern of gunicorn server.
 #   According to its doc, we should use async workers so that those time-consuming requests won't block the worker.
 #   It's set to gevent now, since the other async choice for us, gthread workers, are suitable for CPU bound tasks,
 #   instead of I/O bound tasks in our case.
 gunicorn lira.lira:app -b 0.0.0.0:"${port}" \
     --workers $((2 * $(getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 2) + 1)) \
-    --timeout 60 \
-    --graceful-timeout 60 \
+    --timeout 180 \
+    --graceful-timeout 180 \
     --worker-class gevent


### PR DESCRIPTION
### Purpose
https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530?selectedIssue=GH-470

Update Lira to add DSS notifications to a google pub/sub topic to fix the timeout/duplicate notifications issue.

### Changes
- Add a new endpoint to Lira that subscribes to the pub/sub topic that contains notifications, and then submits an on-hold workflow to Cromwell.

### Review Instructions
Note: This is only set up for the `broad-dsde-mint-dev` project for testing at the moment. The topic is "hca-notifications-dev" and the subscription is "test-push-subscription"

Using the secondary-analysis/tests/integration_test/run_int_test_locally.sh script, it is possible to test the latest commit on this branch in the "dev" Lira environment.

### Set Up Requirements
For each environment:

- [x] Create a pub/sub topic "hca-notifications-{env}"
- [x] Give the caas service account IAM permissions to publish messages 
- [ ] Verify the domain ownership of "{env}.data.humancellatlas.org" (required for creating subscriptions)
- [ ] Create a subscription with the acknowledgement timeout set to 180s (ensure the pub/sub service account has service account token creator role)
- [x] Change GKE load balancer timeout to 180s 

Note: Set-up is complete for dev, integration and staging