### PR TITLE
Add input hash label to workflows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ python:
 
 install: "pip install -r requirements.txt"
 
+before_install:
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools
+
 jobs:
   include:
     # The linting test is fast and cheap so run it first

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -7,7 +7,7 @@ import cromwell_tools.cromwell_api
 import cromwell_tools.cromwell_auth
 import cromwell_tools.utilities
 from flask import current_app
-from lira import lira_utils
+from lira import lira_utils, bundle_inputs
 from google.cloud import pubsub_v1
 
 
@@ -96,6 +96,9 @@ def submit_workflow(message):
     attachments_from_notification = body.get(
         "attachments"
     )  # Try to get the extra attachments field if it's applicable
+    workflow_hash_label = bundle_inputs.create_workflow_inputs_hash_label(
+        wdl_config.workflow_name, uuid, version, lira_config.dss_url
+    )
     cromwell_labels = lira_utils.compose_labels(
         wdl_config.workflow_name,
         wdl_config.workflow_version,
@@ -103,6 +106,7 @@ def submit_workflow(message):
         version,
         labels_from_notification,
         attachments_from_notification,
+        workflow_hash_label,
     )
     cromwell_labels_file = json.dumps(cromwell_labels).encode("utf-8")
 

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -37,7 +37,9 @@ def post(body):
     topic_path = publisher.topic_path(project_id, topic_name)
     message = json.dumps(body).encode("utf-8")
     future = publisher.publish(topic_path, message, origin=f"lira-{lira_config.env}")
-    message_id = future.result(timeout=60)  # Wait 60s for a value to be returned, otherwise raise a timeout error
+    message_id = future.result(
+        timeout=60
+    )  # Wait 60s for a value to be returned, otherwise raise a timeout error
     logger.info(f"Message {message_id} added to topic {topic_name}")
     return lira_utils.response_with_server_header({"id": message_id}, 200)
 

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -98,7 +98,7 @@ def submit_workflow(message):
     attachments_from_notification = body.get(
         "attachments"
     )  # Try to get the extra attachments field if it's applicable
-    workflow_hash_label = bundle_inputs.create_workflow_inputs_hash_label(
+    workflow_hash_label = bundle_inputs.get_workflow_inputs_to_hash(
         wdl_config.workflow_name, uuid, version, lira_config.dss_url
     )
     cromwell_labels = lira_utils.compose_labels(

--- a/lira/bundle_inputs.py
+++ b/lira/bundle_inputs.py
@@ -9,7 +9,7 @@ WORKFLOW_INPUTS = {
 
 
 def create_workflow_inputs_hash_label(
-        workflow_name, bundle_id, bundle_version, dss_url
+    workflow_name, bundle_id, bundle_version, dss_url
 ):
     """
     Create a hash out of the bundle-specific inputs for a workflow.

--- a/lira/bundle_inputs.py
+++ b/lira/bundle_inputs.py
@@ -1,0 +1,24 @@
+import hashlib
+from pipeline_tools.pipelines.smartseq2 import smartseq2
+from pipeline_tools.pipelines.optimus import optimus
+
+WORKFLOW_INPUTS = {
+    'AdapterSmartSeq2SingleCell': smartseq2.get_ss2_paired_end_inputs_to_hash,
+    'AdapterOptimus': optimus.get_optimus_inputs_to_hash,
+}
+
+
+def create_workflow_inputs_hash_label(
+        workflow_name, bundle_id, bundle_version, dss_url
+):
+    """
+    Create a hash out of the bundle-specific inputs for a workflow.
+    """
+    get_inputs_to_hash = WORKFLOW_INPUTS.get(workflow_name, None)
+    if get_inputs_to_hash:
+        workflow_inputs = get_inputs_to_hash(bundle_id, bundle_version, dss_url)
+
+        sha256_hash = hashlib.sha256(
+            bytes(''.join((str(i) for i in workflow_inputs)), encoding='utf-8')
+        )
+        return {'hash-id': sha256_hash.hexdigest()}

--- a/lira/bundle_inputs.py
+++ b/lira/bundle_inputs.py
@@ -8,17 +8,37 @@ WORKFLOW_INPUTS = {
 }
 
 
-def create_workflow_inputs_hash_label(
-    workflow_name, bundle_id, bundle_version, dss_url
-):
+def get_workflow_inputs_to_hash(workflow_name, bundle_id, bundle_version, dss_url):
     """
-    Create a hash out of the bundle-specific inputs for a workflow.
+    Get the bundle-specific inputs for a workflow.
+
+    Args:
+        workflow_name (str): The name of the WDL workflow
+        bundle_id (str): The UUID of the HCA data bundle
+        bundle_version (str): The version timestamp of the HCA data bundle
+        dss_url (str): The URL to a particular HCA Data Store environment
+
+    Returns:
+        dict: A dictionary of {'hash-id': <SHA-256 hexadecimal hash>}
     """
     get_inputs_to_hash = WORKFLOW_INPUTS.get(workflow_name, None)
     if get_inputs_to_hash:
         workflow_inputs = get_inputs_to_hash(bundle_id, bundle_version, dss_url)
+        workflow_inputs_hash = get_hash_id(workflow_inputs)
+        return {'hash-id': workflow_inputs_hash}
 
-        sha256_hash = hashlib.sha256(
-            bytes(''.join((str(i) for i in workflow_inputs)), encoding='utf-8')
-        )
-        return {'hash-id': sha256_hash.hexdigest()}
+
+def get_hash_id(workflow_inputs):
+    """
+    Create a SHA-256 hash of the values in workflow_inputs.
+
+    Args:
+        workflow_inputs (tuple): Tuple of bundle-specific inputs to the workflow
+
+    Returns:
+        str: SHA-256 hexadecimal hash
+    """
+    sha256_hash = hashlib.sha256(
+        bytes(''.join((str(i) for i in workflow_inputs)), encoding='utf-8')
+    )
+    return sha256_hash.hexdigest()

--- a/lira/lira_api.yml
+++ b/lira/lira_api.yml
@@ -254,7 +254,6 @@ definitions:
             example: "v1.0.0"
           lira_version:
             type: string
-            pattern: '(v)?([0-9]+)\.([0-9]+)\.([0-9]+)'
             example: "v1.0.0"
           submit_wdl_version:
             type: string

--- a/lira/lira_config.py
+++ b/lira/lira_config.py
@@ -261,7 +261,7 @@ class LiraConfig(Config):
             'ingest_url',
             'schema_url',
             'DOMAIN',
-            'google_project'
+            'google_project',
         }
 
     @staticmethod
@@ -305,7 +305,7 @@ class LiraConfig(Config):
             self.ingest_url,
             self.schema_url,
             self.DOMAIN,
-            self.google_project
+            self.google_project,
         )
 
     def __repr__(self):
@@ -335,7 +335,7 @@ class LiraConfig(Config):
             self.ingest_url,
             self.schema_url,
             self.DOMAIN,
-            self.google_project
+            self.google_project,
         )
 
 

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -41,6 +41,7 @@ def _is_authenticated_pubsub(request):
         logger.error(f'Invalid token: {e}\n')
         return False
 
+
 def response_with_server_header(body, status):
     """Add information of server to header.
 

--- a/lira/test/data/config.json
+++ b/lira/test/data/config.json
@@ -1,6 +1,7 @@
 {
   "version": "v0.1.0",
   "env": "dev",
+  "google_project": "broad-dsde-mint-dev",
   "cromwell_url": "https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1",
   "cromwell_user": "test",
   "cromwell_password": "test",

--- a/lira/test/test_bundle_inputs.py
+++ b/lira/test/test_bundle_inputs.py
@@ -1,0 +1,66 @@
+import hashlib
+import unittest
+from unittest import mock
+from lira import bundle_inputs
+from pipeline_tools.shared.metadata_utils import get_hashes_from_file_manifest
+from humancellatlas.data.metadata.api import ManifestEntry
+
+
+class TestGetBundleInputs(unittest.TestCase):
+    def setUp(self):
+        self.workflow_name = 'AdapterSmartSeq2SingleCell'
+        self.sample_id = 'sample_id'
+        self.taxon_id = 'taxon_id'
+        self.fastq1_manifest = ManifestEntry(
+            url='gs://foo/read1.fastq',
+            sha1='sha1_read1',
+            sha256='sha256_read1',
+            s3_etag='s3_etag_read1',
+            crc32c='crc32c_read1',
+            uuid='1',
+            version='v1',
+            size='100',
+            name='read1.fastq',
+            indexed=True,
+            content_type='fastq',
+        )
+        self.fastq2_manifest = ManifestEntry(
+            url='gs://foo/read2.fastq',
+            sha1='sha1_read2',
+            sha256='sha256_read2',
+            s3_etag='s3_etag_read2',
+            crc32c='crc32c_read2',
+            uuid='2',
+            version='v1',
+            size='100',
+            name='read2.fastq',
+            indexed=True,
+            content_type='fastq',
+        )
+
+    @mock.patch(
+        'pipeline_tools.pipelines.smartseq2.smartseq2.get_ss2_paired_end_inputs'
+    )
+    def test_create_workflow_inputs_hash_label(self, mock_hash):
+        expected_inputs = (
+            self.sample_id,
+            self.taxon_id,
+            self.fastq1_manifest,
+            self.fastq2_manifest,
+        )
+        mock_hash.return_value = expected_inputs
+        workflow_hash = bundle_inputs.create_workflow_inputs_hash_label(
+            workflow_name=self.workflow_name,
+            bundle_id='fake_id',
+            bundle_version='fake_version',
+            dss_url='https://fake-url.org',
+        )
+        r1_file_hashes = get_hashes_from_file_manifest(self.fastq1_manifest)
+        r2_file_hashes = get_hashes_from_file_manifest(self.fastq2_manifest)
+        expected_hash = hashlib.sha256(
+            bytes(
+                f'{self.sample_id}{self.taxon_id}{r1_file_hashes}{r2_file_hashes}',
+                encoding='utf-8',
+            )
+        )
+        self.assertEquals(workflow_hash['hash-id'], expected_hash.hexdigest())

--- a/lira/test/test_bundle_inputs.py
+++ b/lira/test/test_bundle_inputs.py
@@ -1,6 +1,5 @@
 import hashlib
 import unittest
-from unittest import mock
 from lira import bundle_inputs
 from pipeline_tools.shared.metadata_utils import get_hashes_from_file_manifest
 from humancellatlas.data.metadata.api import ManifestEntry
@@ -37,30 +36,21 @@ class TestGetBundleInputs(unittest.TestCase):
             indexed=True,
             content_type='fastq',
         )
+        self.r1_file_hashes = get_hashes_from_file_manifest(self.fastq1_manifest)
+        self.r2_file_hashes = get_hashes_from_file_manifest(self.fastq2_manifest)
 
-    @mock.patch(
-        'pipeline_tools.pipelines.smartseq2.smartseq2.get_ss2_paired_end_inputs'
-    )
-    def test_create_workflow_inputs_hash_label(self, mock_hash):
-        expected_inputs = (
+    def test_get_hash_id(self):
+        workflow_inputs = (
             self.sample_id,
             self.taxon_id,
-            self.fastq1_manifest,
-            self.fastq2_manifest,
+            self.r1_file_hashes,
+            self.r2_file_hashes,
         )
-        mock_hash.return_value = expected_inputs
-        workflow_hash = bundle_inputs.create_workflow_inputs_hash_label(
-            workflow_name=self.workflow_name,
-            bundle_id='fake_id',
-            bundle_version='fake_version',
-            dss_url='https://fake-url.org',
-        )
-        r1_file_hashes = get_hashes_from_file_manifest(self.fastq1_manifest)
-        r2_file_hashes = get_hashes_from_file_manifest(self.fastq2_manifest)
+        workflow_inputs_hash = bundle_inputs.get_hash_id(workflow_inputs)
         expected_hash = hashlib.sha256(
             bytes(
-                f'{self.sample_id}{self.taxon_id}{r1_file_hashes}{r2_file_hashes}',
+                f'{self.sample_id}{self.taxon_id}{self.r1_file_hashes}{self.r2_file_hashes}',
                 encoding='utf-8',
             )
         )
-        self.assertEquals(workflow_hash['hash-id'], expected_hash.hexdigest())
+        self.assertEquals(workflow_inputs_hash, expected_hash.hexdigest())

--- a/lira/test/test_config.py
+++ b/lira/test/test_config.py
@@ -143,13 +143,6 @@ class TestStartupVerification(unittest.TestCase):
         config = lira_config.LiraConfig(test_config)
         self.assertTrue(config.use_caas)
 
-    def test_using_caas_requires_google_project(self):
-        test_config = deepcopy(self.correct_test_config)
-        test_config['use_caas'] = 'true'
-        test_config['gcs_root'] = 'fake gcs root'
-        with self.assertRaises(ValueError):
-            config = lira_config.LiraConfig(test_config)
-
     def test_using_caas_requires_gcs_root(self):
         test_config = deepcopy(self.correct_test_config)
         test_config['use_caas'] = 'true'

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ black==19.3b0
 flake8==3.7.7
 pre-commit==1.14.4
 google-cloud-pubsub==0.39.1
+git+git://github.com/HumanCellAtlas/pipeline-tools@v0.56.3

--- a/start_lira.sh
+++ b/start_lira.sh
@@ -14,17 +14,17 @@ fi
 #   requests will break/block the main process and cause CRITICAL TIMEOUTS problems.
 #   The command will try to get the (2 * current number of CPU cores) + 1 first, if it failed, it will use 5 as the
 #   the number of workers, for portability purposes.
-#--timeout: by default, it's set to 30s, which is not enough for some of the requests that are sent to Cromwell.
-#   It's set to 60 seconds now, which is consistent with the response timeout(NOT the health check timeout) of
+#--timeout: by default, it's set to 30s, which is not enough for some of the requests that are sent to Cromwell or the
+#   HCA Data Store. It's set to 180 seconds now, which is consistent with the response timeout(NOT the health check timeout) of
 #   our GKE Load Balancer.
 #--graceful-timeout: by default, it's set to 30s, this parameter helps the workers reboot gracefully,
-#   instead of shutting down immediately. It's set to 60s now to be consistent with the timeouts.
+#   instead of shutting down immediately. It's set to 180s now to be consistent with the timeouts.
 #--worker-class: this is the critical parameter that controls the working pattern of gunicorn server.
 #   According to its doc, we should use async workers so that those time-consuming requests won't block the worker.
 #   It's set to gevent now, since the other async choice for us, gthread workers, are suitable for CPU bound tasks,
 #   instead of I/O bound tasks in our case.
 gunicorn lira.lira:app -b 0.0.0.0:"${port}" \
     --workers $((2 * $(getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 2) + 1)) \
-    --timeout 60 \
-    --graceful-timeout 60 \
+    --timeout 180 \
+    --graceful-timeout 180 \
     --worker-class gevent


### PR DESCRIPTION
### Purpose
Add input hash labeling back into Lira

### Changes
Add a hash of bundle-specific workflow inputs as a label on the Cromwell workflow. Falcon will use this label to determine whether to start a workflow.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
