### PR TITLE
Fix default subscription type

### DIFF
--- a/subscription/subscription-create.sh
+++ b/subscription/subscription-create.sh
@@ -24,6 +24,6 @@ python3 subscribe.py create --dss_url="$dss_url" \
                             --replica="$replica" \
                             --callback_base_url="$lira_url" \
                             --query_file="$query_file" \
-                            --subscription_type="jmespath" \
+                            --subscription_type="elasticsearch" \
                             $(echo "$auth_args" | xargs) \
                             "$additional_metadata_flag""$additional_metadata"

--- a/subscription/subscription-delete.sh
+++ b/subscription/subscription-delete.sh
@@ -10,5 +10,5 @@ python3 subscribe.py delete --dss_url="$dss_url" \
                             --key_file="$key_file" \
                             --google_project="$google_project" \
                             --replica="$replica" \
-                            --subscription_type="jmespath" \
+                            --subscription_type="elasticsearch" \
                             --subscription_id="$subscription_id"

--- a/subscription/subscriptions-get.sh
+++ b/subscription/subscriptions-get.sh
@@ -8,5 +8,5 @@ source $script_config
 python3 subscribe.py get --dss_url="$dss_url" \
                          --key_file="$key_file" \
                          --google_project="$google_project" \
-                         --subscription_type="jmespath" \
+                         --subscription_type="elasticsearch" \
                          --replica="$replica"


### PR DESCRIPTION
### Purpose
We are still using elasticsearch subscriptions, so the default subscription type in the scripts to get, create and delete subscriptions should be "elasticsearch" instead of "jmespath"