### PR TITLE
Update subscription queries

### DIFF
--- a/subscription/elasticsearch_queries/10x-query.json
+++ b/subscription/elasticsearch_queries/10x-query.json
@@ -18,8 +18,19 @@
           }
         },
         {
-          "match": {
-            "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": 9606
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": 9606
+                }
+              },
+              {
+                "match": {
+                  "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": 10090
+                }
+              }
+            ]
           }
         },
         {
@@ -761,20 +772,6 @@
         {
           "match": {
             "files.analysis_process_json.type.text": "analysis"
-          }
-        },
-        {
-          "range": {
-            "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": {
-              "lt": 9606
-            }
-          }
-        },
-        {
-          "range": {
-            "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": {
-              "gt": 9606
-            }
           }
         }
       ]

--- a/subscription/elasticsearch_queries/smartseq2-query.json
+++ b/subscription/elasticsearch_queries/smartseq2-query.json
@@ -13,8 +13,19 @@
           }
         },
         {
-          "match": {
-            "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": 9606
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": 9606
+                }
+              },
+              {
+                "match": {
+                  "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": 10090
+                }
+              }
+            ]
           }
         },
         {
@@ -763,20 +774,6 @@
         {
           "match": {
             "files.analysis_process_json.type.text": "analysis"
-          }
-        },
-        {
-          "range": {
-            "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": {
-              "lt": 9606
-            }
-          }
-        },
-        {
-          "range": {
-            "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": {
-              "gt": 9606
-            }
           }
         }
       ]

--- a/subscription/elasticsearch_queries/smartseq2-query.json
+++ b/subscription/elasticsearch_queries/smartseq2-query.json
@@ -758,18 +758,6 @@
           }
         }
       ],
-      "should": [
-        {
-          "match": {
-            "files.dissociation_protocol_json.method.ontology": "EFO:0009108"
-          }
-        },
-        {
-          "match": {
-            "files.dissociation_protocol_json.method.text": "mouth pipette"
-          }
-        }
-      ],
       "must_not": [
         {
           "match": {


### PR DESCRIPTION
### Purpose
Now that the SmartSeq2 and Optimus pipelines are approved to analyze mouse data, update the subscription queries to match on either human or mouse data.

### Changes
- Update the subscription queries to match on either human or mouse data
- Remove "should" clause in Lira: https://github.com/HumanCellAtlas/lira/pull/163

### Review Instructions
- No instructions.

Note: The SS2 query should not be replaced until the mouse reference is added to pipeline-tools: https://github.com/HumanCellAtlas/pipeline-tools/pull/170