### PR TITLE
Pass pipeline version to workflow inputs

### DIFF
--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -87,7 +87,7 @@ def submit_workflow(message):
 
     # Prepare inputs
     inputs = lira_utils.compose_inputs(
-        wdl_config.workflow_name, uuid, version, lira_config
+        wdl_config.workflow_name, wdl_config.workflow_version, uuid, version, lira_config
     )
     cromwell_inputs = json.dumps(inputs).encode('utf-8')
 

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -87,7 +87,11 @@ def submit_workflow(message):
 
     # Prepare inputs
     inputs = lira_utils.compose_inputs(
-        wdl_config.workflow_name, wdl_config.workflow_version, uuid, version, lira_config
+        wdl_config.workflow_name,
+        wdl_config.workflow_version,
+        uuid,
+        version,
+        lira_config,
     )
     cromwell_inputs = json.dumps(inputs).encode('utf-8')
 

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -217,7 +217,7 @@ def compose_inputs(workflow_name, workflow_version, uuid, version, lira_config):
         workflow_name + '.schema_url': lira_config.schema_url,
         workflow_name + '.cromwell_url': lira_config.cromwell_url,
         workflow_name + '.timestamp': get_utcnow_timestamp(),
-        workflow_name + '.workflow_version': workflow_version,
+        workflow_name + '.pipeline_version': workflow_version,
     }
 
 

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -195,11 +195,12 @@ def extract_uuid_version_subscription_id(msg):
     return uuid, version, subscription_id
 
 
-def compose_inputs(workflow_name, uuid, version, lira_config):
+def compose_inputs(workflow_name, workflow_version, uuid, version, lira_config):
     """Create Cromwell inputs file containing bundle uuid and version.
 
     Args:
         workflow_name (str): The name of the workflow.
+        workflow_version (str): The version of the workflow.
         uuid (str): uuid of the bundle.
         version (str): version of the bundle.
         lira_config (LiraConfig): Lira configuration
@@ -216,6 +217,7 @@ def compose_inputs(workflow_name, uuid, version, lira_config):
         workflow_name + '.schema_url': lira_config.schema_url,
         workflow_name + '.cromwell_url': lira_config.cromwell_url,
         workflow_name + '.timestamp': get_utcnow_timestamp(),
+        workflow_name + '.workflow_version': workflow_version,
     }
 
 

--- a/lira/test/test_lira_utils.py
+++ b/lira/test/test_lira_utils.py
@@ -419,9 +419,18 @@ class TestUtils(unittest.TestCase):
         """Test if compose_inputs can correctly create Cromwell inputs file containing bundle uuid and version"""
         test_config = deepcopy(self.correct_test_config)
         config = lira_config.LiraConfig(test_config)
-        inputs = lira_utils.compose_inputs('foo', 'bar', 'baz', config)
-        self.assertEqual(inputs['foo.bundle_uuid'], 'bar')
-        self.assertEqual(inputs['foo.bundle_version'], 'baz')
+        workflow_version = 'v1.0.0'
+        bundle_uuid = 'fake_bundle_uuid'
+        bundle_version = 'fake_bundle_version'
+        inputs = lira_utils.compose_inputs(
+            workflow_name='foo',
+            workflow_version=workflow_version,
+            uuid=bundle_uuid,
+            version=bundle_version,
+            lira_config=config,
+        )
+        self.assertEqual(inputs['foo.bundle_uuid'], bundle_uuid)
+        self.assertEqual(inputs['foo.bundle_version'], bundle_version)
         self.assertEqual(inputs['foo.runtime_environment'], 'dev')
         self.assertEqual(
             inputs['foo.dss_url'], 'https://dss.dev.data.humancellatlas.org/v1'
@@ -433,6 +442,7 @@ class TestUtils(unittest.TestCase):
             inputs['foo.cromwell_url'],
             'https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1',
         )
+        self.assertEqual(inputs['foo.pipeline_version'], workflow_version)
 
     def test_compose_caas_options(self):
         test_config = deepcopy(self.correct_test_config)


### PR DESCRIPTION
### Purpose
Getting the pipeline version from the outputs of the analysis workflow requires keeping that hard-coded version variable up to date in the analysis pipeline. This is prone to manual errors and complicates the release process for pipelines in Skylab.

### Changes
Since Lira already knows the pipeline version, pass it into the workflow inputs.

### Review Instructions
- No instructions.
