### PR TITLE
Fix monitoring image setup

### DIFF
--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -265,7 +265,7 @@ def compose_config_options(cromwell_options_file, lira_config):
     if isinstance(cromwell_options_file, bytes):
         cromwell_options_file = cromwell_options_file.decode()
     options_json = json.loads(cromwell_options_file)
-    
+
     # If a monitoring image is defined in the config, add it to the options JSON
     monitoring_image = getattr(lira_config, 'monitoring_image', None)
     if monitoring_image:

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -270,10 +270,12 @@ def compose_config_options(cromwell_options_file, lira_config):
     monitoring_image = getattr(lira_config, 'monitoring_image', None)
     if monitoring_image:
         options_json['monitoring_image'] = lira_config.monitoring_image
-    
-    # Required to trigger the cloud function that records Cromwell metadata in BigQuery 
-    options_json['final_workflow_log_dir'] = f'{lira_config.google_project}-cromwell-logs'
-    
+
+    # Required to trigger the cloud function that records Cromwell metadata in BigQuery
+    options_json[
+        'final_workflow_log_dir'
+    ] = f'{lira_config.google_project}-cromwell-logs'
+
     # Defer to value already in options file if it exists
     # Docs on default runtime attributes: https://cromwell.readthedocs.io/en/latest/wf_options/Overview/
     runtime_parameters = options_json.get('default_runtime_attributes', {})

--- a/lira/lira_utils.py
+++ b/lira/lira_utils.py
@@ -265,12 +265,15 @@ def compose_config_options(cromwell_options_file, lira_config):
     if isinstance(cromwell_options_file, bytes):
         cromwell_options_file = cromwell_options_file.decode()
     options_json = json.loads(cromwell_options_file)
-
+    
     # If a monitoring image is defined in the config, add it to the options JSON
     monitoring_image = getattr(lira_config, 'monitoring_image', None)
     if monitoring_image:
         options_json['monitoring_image'] = lira_config.monitoring_image
-
+    
+    # Required to trigger the cloud function that records Cromwell metadata in BigQuery 
+    options_json['final_workflow_log_dir'] = f'{lira_config.google_project}-cromwell-logs'
+    
     # Defer to value already in options file if it exists
     # Docs on default runtime attributes: https://cromwell.readthedocs.io/en/latest/wf_options/Overview/
     runtime_parameters = options_json.get('default_runtime_attributes', {})


### PR DESCRIPTION
### Purpose
Fix set-up for recording workflow metadata in BigQuery.

### Changes
Add `final_workflow_log_dir` to workflow options -- writing to this directory will trigger the Google cloud function that records metadata when each workflow completes: 
https://github.com/broadinstitute/cromwell-task-monitor-bq#metadata-upload

### Review Instructions
- No instructions.
