### PR TITLE
Update pubsub configuration

### DIFF
--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -33,8 +33,7 @@ def post(body):
     topic_name = lira_config.google_pubsub_topic
     batch_settings = pubsub_v1.types.BatchSettings(max_messages=1)
     publisher = pubsub_v1.PublisherClient.from_service_account_file(
-        lira_config.caas_key,
-        batch_settings=batch_settings
+        lira_config.caas_key, batch_settings=batch_settings
     )
     topic_path = publisher.topic_path(project_id, topic_name)
     message = json.dumps(body).encode("utf-8")

--- a/lira/api/notifications.py
+++ b/lira/api/notifications.py
@@ -31,8 +31,10 @@ def post(body):
 
     project_id = lira_config.google_project
     topic_name = lira_config.google_pubsub_topic
+    batch_settings = pubsub_v1.types.BatchSettings(max_messages=1)
     publisher = pubsub_v1.PublisherClient.from_service_account_file(
-        lira_config.caas_key
+        lira_config.caas_key,
+        batch_settings=batch_settings
     )
     topic_path = publisher.topic_path(project_id, topic_name)
     message = json.dumps(body).encode("utf-8")


### PR DESCRIPTION
### Purpose
When using the notifier script to manually send notifications to Lira, the response time for a single request can take up to 10 seconds, which makes starting analysis of a dataset take significantly longer 🙀 The only task that is being performed at that stage is publishing the message to the pubsub topic, so the configuration should be changed to make this faster.

### Changes
Set the batch message number to 1, so that messages are immediately published to the topic (instead of waiting for multiple messages to send as a batch).

See "Batching to Balance Latency" documentation on publisher client: https://cloud.google.com/pubsub/docs/publisher

### Review Instructions
- No instructions.
